### PR TITLE
parallelize everything

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_distr",
+ "rayon",
  "serde",
  "thiserror",
  "zeroize",

--- a/crates/fhe/Cargo.toml
+++ b/crates/fhe/Cargo.toml
@@ -26,6 +26,7 @@ prost.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 rand_distr.workspace = true
+rayon.workspace = true
 zeroize.workspace = true
 zeroize_derive.workspace = true
 ndarray.workspace = true

--- a/crates/fhe/examples/trbfv_add.rs
+++ b/crates/fhe/examples/trbfv_add.rs
@@ -15,6 +15,7 @@ use fhe_math::rq::{Poly, Representation};
 use fhe_traits::{FheDecoder, FheEncoder, FheEncrypter};
 use ndarray::{Array, Array2, ArrayView};
 use rand::{distributions::Uniform, prelude::Distribution, rngs::OsRng, thread_rng};
+use rayon::prelude::*;
 use util::timeit::{timeit, timeit_n};
 
 fn print_notice_and_exit(error: Option<String>) {
@@ -131,7 +132,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         es_poly_sum: Poly,
         d_share_poly: Poly,
     }
-    let mut parties = Vec::with_capacity(num_parties);
 
     // Generate a common reference poly for public key generation.
     let crp = CommonRandomPoly::new(&params, &mut thread_rng())?;
@@ -139,36 +139,61 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Setup trBFV module
     let mut trbfv = TRBFV::new(num_parties, threshold, params.clone()).unwrap();
 
-    // Set up shares for each party.
-    timeit_n!("Party setup (per party)", num_parties as u32, {
-        let sk_share = SecretKey::random(&params, &mut OsRng);
-        let pk_share = PublicKeyShare::new(&sk_share, crp.clone(), &mut thread_rng())?;
+    // Set up shares for each party in parallel
+    println!("💻 Available CPU cores: {}", rayon::current_num_threads());
+    let mut parties: Vec<Party> = timeit!("Party setup (parallel)", {
+        (0..num_parties)
+            .into_par_iter()
+            .map(|_| {
+                // Each thread gets its own RNG to avoid contention
+                let mut rng = OsRng;
+                let mut thread_rng = thread_rng();
 
-        let mut share_manager = ShareManager::new(num_parties, threshold, params.clone());
-        let sk_poly = share_manager.coeffs_to_poly_level0(sk_share.coeffs.clone().as_ref())?;
-        let sk_sss = trbfv.generate_secret_shares_from_poly(sk_poly)?;
+                let sk_share = SecretKey::random(&params, &mut rng);
+                let pk_share =
+                    PublicKeyShare::new(&sk_share, crp.clone(), &mut thread_rng).unwrap();
 
-        // vec of 3 moduli and array2 for num_parties rows of coeffs and degree columns
-        let sk_sss_collected: Vec<Array2<u64>> = Vec::with_capacity(num_parties);
-        let es_sss_collected: Vec<Array2<u64>> = Vec::with_capacity(num_parties);
-        let sk_poly_sum = Poly::zero(params.ctx_at_level(0).unwrap(), Representation::PowerBasis);
-        let es_poly_sum = Poly::zero(params.ctx_at_level(0).unwrap(), Representation::PowerBasis);
-        let d_share_poly = Poly::zero(params.ctx_at_level(0).unwrap(), Representation::PowerBasis);
+                let mut share_manager = ShareManager::new(num_parties, threshold, params.clone());
+                let sk_poly = share_manager
+                    .coeffs_to_poly_level0(sk_share.coeffs.clone().as_ref())
+                    .unwrap();
 
-        let esi_coeffs = trbfv.generate_smudging_error(num_summed, &mut OsRng)?;
-        let esi_poly = share_manager.bigints_to_poly(&esi_coeffs)?;
-        let esi_sss = share_manager.generate_secret_shares_from_poly(esi_poly)?;
+                // Clone trbfv for thread safety (it's cheap since it's just config)
+                let mut temp_trbfv = trbfv.clone();
+                let sk_sss = temp_trbfv
+                    .generate_secret_shares_from_poly(sk_poly)
+                    .unwrap();
 
-        parties.push(Party {
-            pk_share,
-            sk_sss,
-            esi_sss,
-            sk_sss_collected,
-            es_sss_collected,
-            sk_poly_sum,
-            es_poly_sum,
-            d_share_poly,
-        });
+                // vec of 3 moduli and array2 for num_parties rows of coeffs and degree columns
+                let sk_sss_collected: Vec<Array2<u64>> = Vec::with_capacity(num_parties);
+                let es_sss_collected: Vec<Array2<u64>> = Vec::with_capacity(num_parties);
+                let sk_poly_sum =
+                    Poly::zero(params.ctx_at_level(0).unwrap(), Representation::PowerBasis);
+                let es_poly_sum =
+                    Poly::zero(params.ctx_at_level(0).unwrap(), Representation::PowerBasis);
+                let d_share_poly =
+                    Poly::zero(params.ctx_at_level(0).unwrap(), Representation::PowerBasis);
+
+                let esi_coeffs = temp_trbfv
+                    .generate_smudging_error(num_summed, &mut rng)
+                    .unwrap();
+                let esi_poly = share_manager.bigints_to_poly(&esi_coeffs).unwrap();
+                let esi_sss = share_manager
+                    .generate_secret_shares_from_poly(esi_poly)
+                    .unwrap();
+
+                Party {
+                    pk_share,
+                    sk_sss,
+                    esi_sss,
+                    sk_sss_collected,
+                    es_sss_collected,
+                    sk_poly_sum,
+                    es_poly_sum,
+                    d_share_poly,
+                }
+            })
+            .collect()
     });
 
     // Swap shares mocking network comms, party 1 sends share 2 to party 2 etc.
@@ -180,7 +205,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             for j in 0..num_parties {
                 let mut node_share_m = Array::zeros((0, degree));
                 let mut es_node_share_m = Array::zeros((0, degree));
-                for m in 0..moduli.len() {
+                for m in 0..params.moduli().len() {
                     node_share_m
                         .push_row(ArrayView::from(&parties[j].sk_sss[m].row(i).clone()))
                         .unwrap();
@@ -195,16 +220,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     );
 
-    i = 0;
-    // For each party, convert shares to polys and sum the collected shares.
-    timeit_n!("Sum collected shares (per party)", num_parties as u32, {
-        parties[i].sk_poly_sum = trbfv
-            .aggregate_collected_shares(&parties[i].sk_sss_collected)
-            .unwrap();
-        parties[i].es_poly_sum = trbfv
-            .aggregate_collected_shares(&parties[i].es_sss_collected)
-            .unwrap();
-        i += 1;
+    timeit!("Sum collected shares (parallel)", {
+        parties.par_iter_mut().for_each(|party| {
+            let mut temp_trbfv = trbfv.clone();
+            party.sk_poly_sum = temp_trbfv
+                .aggregate_collected_shares(&party.sk_sss_collected)
+                .unwrap();
+            party.es_poly_sum = temp_trbfv
+                .aggregate_collected_shares(&party.es_sss_collected)
+                .unwrap();
+        });
     });
 
     // Aggregation: same as previous mbfv aggregations
@@ -219,14 +244,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         .sample_iter(&mut thread_rng())
         .take(num_summed)
         .collect();
-    let mut numbers_encrypted = Vec::with_capacity(num_summed);
-    let mut _i = 0;
-    timeit_n!("Encrypting Numbers (per encryption)", num_summed as u32, {
-        #[allow(unused_assignments)]
-        let pt = Plaintext::try_encode(&[numbers[_i]], Encoding::poly(), &params)?;
-        let ct = pk.try_encrypt(&pt, &mut thread_rng())?;
-        numbers_encrypted.push(ct);
-        _i += 1;
+
+    let numbers_encrypted: Vec<Ciphertext> = timeit!("Encrypting Numbers (parallel)", {
+        numbers
+            .par_iter()
+            .map(|&number| {
+                let mut rng = thread_rng();
+                let pt = Plaintext::try_encode(&[number], Encoding::poly(), &params).unwrap();
+                pk.try_encrypt(&pt, &mut rng).unwrap()
+            })
+            .collect()
     });
 
     // calculation
@@ -238,17 +265,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         Arc::new(sum)
     });
 
-    // decrypt
-    i = 0;
-    timeit_n!("Generate Decrypt Share (per party)", num_parties as u32, {
-        parties[i].d_share_poly = trbfv
-            .decryption_share(
-                tally.clone(),
-                parties[i].sk_poly_sum.clone(),
-                parties[i].es_poly_sum.clone(),
-            )
-            .unwrap();
-        i += 1;
+    timeit!("Generate Decrypt Share (parallel)", {
+        parties.par_iter_mut().for_each(|party| {
+            party.d_share_poly = trbfv
+                .clone()
+                .decryption_share(
+                    tally.clone(),
+                    party.sk_poly_sum.clone(),
+                    party.es_poly_sum.clone(),
+                )
+                .unwrap();
+        });
     });
 
     // gather d_share_polys
@@ -258,9 +285,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // decrypt result
-    let open_results = trbfv.decrypt(d_share_polys, tally.clone()).unwrap();
-    let result_vec = Vec::<u64>::try_decode(&open_results, Encoding::poly())?;
-    let result = result_vec[0];
+    let (_open_results, result) = timeit!("Threshold decrypt (combine shares)", {
+        let open_results = trbfv.decrypt(d_share_polys, tally.clone()).unwrap();
+        let result_vec = Vec::<u64>::try_decode(&open_results, Encoding::poly())?;
+        let result = result_vec[0];
+        (open_results, result)
+    });
 
     // Show summation result
     println!("Sum result = {result} / {num_summed}");

--- a/crates/fhe/src/trbfv/normal.rs
+++ b/crates/fhe/src/trbfv/normal.rs
@@ -6,11 +6,17 @@ use core::f64::consts::PI;
 use num_bigint::BigInt;
 use num_traits::{ToPrimitive, Zero};
 use rand::Rng;
+use rayon::prelude::*;
 
 /// Draw `n` samples from centered truncated Gaussian with sigma = bound/3.
 pub fn sample_bigint_normal_vec(bound: &BigInt, n: usize) -> Vec<BigInt> {
-    let mut rng = rand::thread_rng();
-    (0..n).map(|_| sample_single(bound, &mut rng)).collect()
+    (0..n)
+        .into_par_iter()
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            sample_single(bound, &mut rng)
+        })
+        .collect()
 }
 
 /// Sample a single value from N(0, (bound/3)²) truncated to [-bound, bound].


### PR DESCRIPTION
this PR makes the following things computed in parallel:

- party setup: each party generates shares independently
- sum collected shares: each party aggregates shares independently
- encrypting numbers: each encryption runs independently
- generate decrypt share: each party computes decrypt share independently

I touched `shamir`, `normal` and `shares` mods + `trbfv` example has been improved a lot.

tl;dr on numbers
- setup time: 6.35 minutes → 0.83 minutes (7.7× faster)
- runtime operations: 2+ minutes → 15 seconds (8-10× faster)
- overall speedup: 8.45 minutes → 1.11 minutes

you can check the runs by yourself. I have used myM4 Pro - 14 Cores - 48gb ram to run them with the latest params and updates from #33.

# Vanilla

### Run 1
        num_summed = 1000
        num_parties = 10
        threshold = 7
⏱  Parameters generation: 377.8 ms
⏱  Party setup (per party): 1778.2 ms * 10 = 17782 ms = 17,7820002 s
⏱  Simulating network (share swapping per party): 9.7 ms * 10 = 97 ms = 0,097 s
⏱  Sum collected shares (per party): 6 ms * 10 = 60 ms = 0,06 s
⏱  Public key aggregation: 4 ms = 0,004 s
⏱  Encrypting Numbers (per encryption): 60.7 ms * 1000 = 60,700 ms = 60.7 s
⏱  Number tallying: 833.4 ms = 0,8334 s
⏱  Generate Decrypt Share (per party): 19.7 ms * 10 = 197 ms = 0,197 s
Sum result = 464 / 1000
Expected result = 464 / 1000

### Run 2
        num_summed = 2000
        num_parties = 20
        threshold = 15
⏱  Parameters generation: 376.3 ms
⏱  Party setup (per party): 6522.6 ms * 20 = 130452 ms = 130,452 s
⏱  Simulating network (share swapping per party): 32.1 ms * 20 = 642 ms = 0,642 s
⏱  Sum collected shares (per party): 11.9 ms * 20 = 238 ms = 0,238 s
⏱  Public key aggregation: 8.2 ms = 0,0082 s
⏱  Encrypting Numbers (per encryption): 60.4 ms * 2000 = 120,800 ms = 120.8 s
⏱  Number tallying: 1971.7 ms = 1,9717 s
⏱  Generate Decrypt Share (per party): 19.9 ms * 20 = 398 ms = 0,398 s
Sum result = 1014 / 2000
Expected result = 1014 / 2000

### Run 3
        num_summed = 3000
        num_parties = 30
        threshold = 21
⏱  Parameters generation: 377.8 ms
⏱  Party setup (per party): 13163.9 ms * 30 = 394917 ms = 394,917 s
⏱  Simulating network (share swapping per party): 64.3 ms * 30 = 1929 ms = 1,929 s
⏱  Sum collected shares (per party): 18 ms * 30 = 540 ms = 0,54 s
⏱  Public key aggregation: 15.1 ms = 0,0151 s
⏱  Encrypting Numbers (per encryption): 60.4 ms * 3000 = 181,200 ms = 181.2 s
⏱  Number tallying: 2789.4 ms = 2,7894 s
⏱  Generate Decrypt Share (per party): 20.1 ms * 30 = 603 ms = 0,603 s
Sum result = 1510 / 3000
Expected result = 1510 / 3000

---

# Parallel

### Run 1
        num_summed = 1000
        num_parties = 10
        threshold = 7
⏱  Parameters generation: 368.8 ms
💻 Available CPU cores: 14
⏱  Party setup (parallel): 7231 ms = 7,231 s
⏱  Simulating network (share swapping per party): 9.9 ms * 10 = 99 ms
⏱  Sum collected shares (parallel): 15.5 ms = 0,0155 s
⏱  Public key aggregation: 4.3 ms = 0,0043 s
⏱  Encrypting Numbers (parallel): 5764.6 ms = 5,7646 s
⏱  Number tallying: 918.8 ms = 0,9188 s
⏱  Generate Decrypt Share (parallel): 24 ms = 0,024 s
⏱  Threshold decrypt (combine shares): 343.8 ms = 0,3438 s
Sum result = 514 / 1000
Expected result = 514 / 1000

### Run 2
        num_summed = 2000
        num_parties = 20
        threshold = 15
⏱  Parameters generation: 383.1 ms
💻 Available CPU cores: 14
⏱  Party setup (parallel): 18875 ms = 18,875 s
⏱  Simulating network (share swapping per party): 33.4 ms * 20 = 668 ms
⏱  Sum collected shares (parallel): 56.1 ms = 0,0561 s
⏱  Public key aggregation: 8.3 ms = 0,0083 s
⏱  Encrypting Numbers (parallel): 12043.5 ms = 12,0435 s
⏱  Number tallying: 1766.2 ms = 1,7662 s
⏱  Generate Decrypt Share (parallel): 49.9 ms = 0,0499 s
⏱  Threshold decrypt (combine shares): 1498.9 ms = 1,4989 s
Sum result = 1047 / 2000
Expected result = 1047 / 2000

### Run 3
        num_summed = 3000
        num_parties = 30
        threshold = 21
⏱  Parameters generation: 387.3 ms
💻 Available CPU cores: 14
⏱  Party setup (parallel): 49087.3 ms = 49,0873 s
⏱  Simulating network (share swapping per party): 66.3 ms * 30 = 1989 ms
⏱  Sum collected shares (parallel): 98.2 ms = 0,0982 s
⏱  Public key aggregation: 12.6 ms = 0,0126 s
⏱  Encrypting Numbers (parallel): 17528.4 ms = 17,5284 s
⏱  Number tallying: 2864.5 ms = 2,8645 s
⏱  Generate Decrypt Share (parallel): 67.4 ms = 0,0674 s
⏱  Threshold decrypt (combine shares): 2948.7 ms = 2,9487 s
Sum result = 1527 / 3000
Expected result = 1527 / 3000

### Run 4
        num_summed = 10000
        num_parties = 100
        threshold = 51
⏱  Parameters generation: 376.2 ms
💻 Available CPU cores: 14
⏱  Party setup (parallel): 1037381.9 ms = 1037,3819 s = 17,2896983333 minutes
⏱  Simulating network (share swapping per party): 364.5 ms * 100 = 36450 ms = 36,45 s
⏱  Sum collected shares (parallel): 716.7 ms = 0,7167 s
⏱  Public key aggregation: 41 ms = 0,041 s
⏱  Encrypting Numbers (parallel): 57648.1 ms = 57,6481 s
⏱  Number tallying: 9528 ms = 9,528 s
⏱  Generate Decrypt Share (parallel): 199.5 ms = 0,1995 s
⏱  Threshold decrypt (combine shares): 10280.3 ms = 10,2803 s
Sum result = 4986 / 10000
Expected result = 4986 / 10000

