### PR TITLE
feat: add deterministic rng

### DIFF
--- a/crates/fhe-math/benches/rq.rs
+++ b/crates/fhe-math/benches/rq.rs
@@ -18,7 +18,7 @@ static MODULI: &[u64; 4] = &[
 
 static DEGREE: &[usize] = &[1024, 2048, 4096, 8192];
 
-fn create_group(c: &mut Criterion, name: String) -> BenchmarkGroup<WallTime> {
+fn create_group(c: &mut Criterion, name: String) -> BenchmarkGroup<'_, WallTime> {
     let mut group = c.benchmark_group(name);
     group.warm_up_time(Duration::from_millis(100));
     group.measurement_time(Duration::from_secs(1));

--- a/crates/fhe-math/src/rq/mod.rs
+++ b/crates/fhe-math/src/rq/mod.rs
@@ -300,7 +300,7 @@ impl Poly {
     }
 
     /// Access the polynomial coefficients in RNS representation.
-    pub fn coefficients(&self) -> ArrayView2<u64> {
+    pub fn coefficients(&self) -> ArrayView2<'_, u64> {
         self.coefficients.view()
     }
 

--- a/crates/fhe/examples/trbfv_add.rs
+++ b/crates/fhe/examples/trbfv_add.rs
@@ -161,7 +161,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 // Clone trbfv for thread safety (it's cheap since it's just config)
                 let mut temp_trbfv = trbfv.clone();
                 let sk_sss = temp_trbfv
-                    .generate_secret_shares_from_poly(sk_poly)
+                    .generate_secret_shares_from_poly(sk_poly, rng)
                     .unwrap();
 
                 // vec of 3 moduli and array2 for num_parties rows of coeffs and degree columns
@@ -179,7 +179,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     .unwrap();
                 let esi_poly = share_manager.bigints_to_poly(&esi_coeffs).unwrap();
                 let esi_sss = share_manager
-                    .generate_secret_shares_from_poly(esi_poly)
+                    .generate_secret_shares_from_poly(esi_poly, rng)
                     .unwrap();
 
                 Party {

--- a/crates/fhe/src/trbfv/shamir.rs
+++ b/crates/fhe/src/trbfv/shamir.rs
@@ -87,13 +87,21 @@ impl ShamirSecretSharing {
     /// # Panics
     ///
     /// Panics if `threshold` is greater than or equal to `share_amount`.
-    pub fn split<R: RngCore + CryptoRng>(&self, secret: BigInt, rng: R) -> Vec<(usize, BigInt)> {
+    pub fn split<R: RngCore + CryptoRng>(
+        &self,
+        secret: BigInt,
+        rng: &mut R,
+    ) -> Vec<(usize, BigInt)> {
         assert!(self.threshold <= (self.share_amount - 1) / 2);
         let polynomial = self.sample_polynomial(secret, rng);
         self.evaluate_polynomial(polynomial)
     }
 
-    fn sample_polynomial<R: RngCore + CryptoRng>(&self, secret: BigInt, mut rng: R) -> Vec<BigInt> {
+    fn sample_polynomial<R: RngCore + CryptoRng>(
+        &self,
+        secret: BigInt,
+        rng: &mut R,
+    ) -> Vec<BigInt> {
         let mut coefficients: Vec<BigInt> = vec![secret];
         let low = BigInt::from(0);
         let high = &self.prime - BigInt::from(1);
@@ -280,7 +288,7 @@ mod tests {
             .unwrap(),
         };
         let secret = BigInt::parse_bytes(b"ffffffffffffffffffffffffffffffffffffff", 16).unwrap();
-        let shares = sss.split(secret.clone(), rand::thread_rng());
+        let shares = sss.split(secret.clone(), &mut rand::thread_rng());
         assert_eq!(secret, sss.recover(&shares[0..sss.threshold + 1]));
     }
 }

--- a/crates/fhe/src/trbfv/shares.rs
+++ b/crates/fhe/src/trbfv/shares.rs
@@ -168,7 +168,7 @@ impl ShareManager {
             .enumerate()
             .map(|(i, (m, p))| -> Result<Array2<u64>, Error> {
                 // Get rng from seed
-                let rng = ChaCha20Rng::seed_from_u64(seeds[i]);
+                let mut rng = ChaCha20Rng::seed_from_u64(seeds[i]);
 
                 // Create shamir object
                 let shamir = ShamirSecretSharing {
@@ -184,7 +184,8 @@ impl ShareManager {
                     // Split the coeff into n shares
                     let secret = c.to_bigint().unwrap();
 
-                    let c_shares = shamir.split(secret.clone(), rng.clone());
+                    let c_shares = shamir.split(secret.clone(), &mut rng);
+
                     // For each share convert to u64
                     let mut c_vec: Vec<u64> = Vec::with_capacity(self.n);
                     for (_, c_share) in c_shares.iter() {

--- a/crates/fhe/src/trbfv/shares.rs
+++ b/crates/fhe/src/trbfv/shares.rs
@@ -16,6 +16,8 @@ use ndarray::Array2;
 use num_bigint::BigUint;
 use num_bigint::{BigInt, ToBigInt};
 use num_traits::{Signed, ToPrimitive};
+use rand::{CryptoRng, Rng, RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;
 use std::sync::Arc;
 use zeroize::Zeroizing;
@@ -138,9 +140,10 @@ impl ShareManager {
     }
 
     /// Generate Shamir Secret Shares for polynomial coefficients from a pre-converted Poly.
-    pub fn generate_secret_shares_from_poly(
+    pub fn generate_secret_shares_from_poly<R: RngCore + CryptoRng>(
         &mut self,
         poly: Zeroizing<Poly>,
+        mut rng: R,
     ) -> Result<Vec<Array2<u64>>, Error> {
         let moduli: Vec<u64> = poly.ctx().moduli().to_vec();
 
@@ -156,10 +159,17 @@ impl ShareManager {
         let coefficients = poly.coefficients();
         let coeff_rows: Vec<_> = coefficients.outer_iter().collect();
 
+        // Generate seeds deterministically from the input RNG
+        let seeds: Vec<u64> = (0..moduli.len()).map(|_| rng.gen()).collect();
+
         let return_vec: Result<Vec<Array2<u64>>, Error> = moduli
             .par_iter()
             .zip(coeff_rows.par_iter())
-            .map(|(m, p)| -> Result<Array2<u64>, Error> {
+            .enumerate()
+            .map(|(i, (m, p))| -> Result<Array2<u64>, Error> {
+                // Get rng from seed
+                let rng = ChaCha20Rng::seed_from_u64(seeds[i]);
+
                 // Create shamir object
                 let shamir = ShamirSecretSharing {
                     threshold: self.threshold,
@@ -173,7 +183,8 @@ impl ShareManager {
                 for c in p.iter() {
                     // Split the coeff into n shares
                     let secret = c.to_bigint().unwrap();
-                    let c_shares = shamir.split(secret.clone());
+
+                    let c_shares = shamir.split(secret.clone(), rng.clone());
                     // For each share convert to u64
                     let mut c_vec: Vec<u64> = Vec::with_capacity(self.n);
                     for (_, c_share) in c_shares.iter() {
@@ -514,7 +525,7 @@ mod tests {
             .unwrap();
 
         let sk_sss = managers[0]
-            .generate_secret_shares_from_poly(sk_poly)
+            .generate_secret_shares_from_poly(sk_poly, rng)
             .unwrap();
 
         let mut sk_sss_collected: Vec<Vec<Array2<u64>>> = vec![vec![], vec![], vec![]];

--- a/crates/fhe/src/trbfv/smudging.rs
+++ b/crates/fhe/src/trbfv/smudging.rs
@@ -14,7 +14,7 @@ use crate::bfv::BfvParameters;
 use crate::Error;
 
 use num_bigint::{BigInt, BigUint, RandBigInt};
-use rand::{thread_rng, Rng};
+use rand::{CryptoRng, Rng, RngCore};
 use std::sync::Arc;
 
 /// Configuration for calculating optimal smudging variance in threshold BFV.
@@ -162,7 +162,10 @@ impl SmudgingNoiseGenerator {
     ///
     /// # Returns
     /// A vector of BigInt coefficients sampled from the normal distribution
-    pub fn generate_smudging_error(&self) -> Result<Vec<BigInt>, Error> {
+    pub fn generate_smudging_error<R: RngCore + CryptoRng>(
+        &self,
+        rng: &mut R,
+    ) -> Result<Vec<BigInt>, Error> {
         let degree = self.params.degree();
 
         // To sample the smudging noise from a normal distribution uncomment the following lines
@@ -174,14 +177,17 @@ impl SmudgingNoiseGenerator {
         // let samples = sample_bigint_normal_vec(&bound, degree);
 
         // Sample degree many noise coefficients uniformly from [-bound, bound]
-        let samples = self.sample_uniform_coefficients(degree);
+        let samples = self.sample_uniform_coefficients(degree, rng);
 
         Ok(samples)
     }
 
     /// Sample uniform coefficients from [-bound, bound]
-    fn sample_uniform_coefficients(&self, count: usize) -> Vec<BigInt> {
-        let mut rng = thread_rng();
+    fn sample_uniform_coefficients<R: RngCore + CryptoRng>(
+        &self,
+        count: usize,
+        rng: &mut R,
+    ) -> Vec<BigInt> {
         let mut samples = Vec::with_capacity(count);
 
         // Pre-calculate bound + 1 for efficiency
@@ -309,11 +315,12 @@ mod tests {
 
     #[test]
     fn test_noise_generation_small_bound() {
+        let mut rng = thread_rng();
         let params = test_params();
         let bound = BigUint::from(1000u64);
         let generator = SmudgingNoiseGenerator::new(params.clone(), bound);
 
-        let result = generator.generate_smudging_error();
+        let result = generator.generate_smudging_error(&mut rng);
         assert!(result.is_ok());
 
         let coefficients = result.unwrap();
@@ -327,22 +334,24 @@ mod tests {
 
     #[test]
     fn test_noise_generation_zero_bound() {
+        let mut rng = thread_rng();
         let params = test_params();
         let bound = BigUint::from(0u64);
         let generator = SmudgingNoiseGenerator::new(params.clone(), bound);
 
-        let coefficients = generator.generate_smudging_error().unwrap();
+        let coefficients = generator.generate_smudging_error(&mut rng).unwrap();
         assert_eq!(coefficients.len(), params.degree());
         assert!(coefficients.iter().all(|x| x.is_zero()));
     }
 
     #[test]
     fn test_noise_generation_large_bound() {
+        let mut rng = thread_rng();
         let params = test_params();
         let large_bound = BigUint::from_str("123456789012345678901234567890").unwrap();
         let generator = SmudgingNoiseGenerator::new(params.clone(), large_bound.clone());
 
-        let coefficients = generator.generate_smudging_error().unwrap();
+        let coefficients = generator.generate_smudging_error(&mut rng).unwrap();
         assert_eq!(coefficients.len(), params.degree());
 
         // Should generate non-zero coefficients with high probability
@@ -358,6 +367,7 @@ mod tests {
     //TODO Replace this test with a more accurate one
     #[test]
     fn test_realistic_parameters_workflow() {
+        let mut rng = thread_rng();
         let params = test_params();
         let n = 3;
         let m = 1;
@@ -368,7 +378,7 @@ mod tests {
 
         let bound = calculator.calculate_sm_bound().unwrap();
         let generator = SmudgingNoiseGenerator::new(params.clone(), bound.clone());
-        let coefficients = generator.generate_smudging_error().unwrap();
+        let coefficients = generator.generate_smudging_error(&mut rng).unwrap();
 
         assert_eq!(coefficients.len(), params.degree());
     }

--- a/crates/fhe/src/trbfv/smudging.rs
+++ b/crates/fhe/src/trbfv/smudging.rs
@@ -229,6 +229,7 @@ mod tests {
     use crate::bfv::BfvParametersBuilder;
     use num_traits::Signed;
     use num_traits::Zero;
+    use rand::thread_rng;
     use std::str::FromStr;
 
     fn test_params() -> Arc<BfvParameters> {

--- a/crates/fhe/src/trbfv/threshold.rs
+++ b/crates/fhe/src/trbfv/threshold.rs
@@ -118,14 +118,14 @@ impl TRBFV {
     pub fn generate_smudging_error<R: RngCore + CryptoRng>(
         &self,
         num_ciphertexts: usize,
-        _rng: &mut R,
+        rng: &mut R,
     ) -> Result<Vec<BigInt>, Error> {
         let config =
             SmudgingBoundCalculatorConfig::new(self.params.clone(), self.n, num_ciphertexts);
         let calculator = SmudgingBoundCalculator::new(config);
         let generator = SmudgingNoiseGenerator::from_bound_calculator(calculator)?;
 
-        generator.generate_smudging_error()
+        generator.generate_smudging_error(rng)
     }
     /// Compute decryption share from ciphertext and secret/smudging polynomials.
     ///

--- a/crates/fhe/src/trbfv/threshold.rs
+++ b/crates/fhe/src/trbfv/threshold.rs
@@ -77,12 +77,13 @@ impl TRBFV {
     ///
     /// # Returns
     /// Vector of share matrices, one per BFV modulus. Each matrix has dimensions [n, degree].
-    pub fn generate_secret_shares_from_poly(
+    pub fn generate_secret_shares_from_poly<R: RngCore + CryptoRng>(
         &mut self,
         poly: Zeroizing<Poly>,
+        rng: R,
     ) -> Result<Vec<Array2<u64>>, Error> {
         let mut share_manager = ShareManager::new(self.n, self.threshold, self.params.clone());
-        share_manager.generate_secret_shares_from_poly(poly)
+        share_manager.generate_secret_shares_from_poly(poly, rng)
     }
 
     /// Aggregate collected secret sharing shares to compute SK_i polynomial sum.
@@ -233,7 +234,9 @@ mod tests {
         let sk_poly = share_manager
             .coeffs_to_poly_level0(sk.coeffs.clone().as_ref())
             .unwrap();
-        let shares = trbfv.generate_secret_shares_from_poly(sk_poly).unwrap();
+        let shares = trbfv
+            .generate_secret_shares_from_poly(sk_poly, rand::thread_rng())
+            .unwrap();
 
         // Check that we got the right number of shares
         assert_eq!(shares.len(), params.moduli().len());
@@ -410,7 +413,7 @@ mod tests {
             .coeffs_to_poly_level0(sk.coeffs.as_ref())
             .unwrap();
 
-        let shares = trbfv.generate_secret_shares_from_poly(sk_poly);
+        let shares = trbfv.generate_secret_shares_from_poly(sk_poly, rand::thread_rng());
         assert!(shares.is_ok());
     }
 }


### PR DESCRIPTION
Currently it is not possible to deterministically test the trbfv functionality as the shamir module makes use of `rand::thread_rng()` directly.

Other `bfv` operations in `fhe.rs` allow for rng injection in order to create deterministic testing scenarios. 

This PR allows injection of an rng in relevant functions around the share generation functionality where previously they automatically used `rand::thread_rng()`



