### PR TITLE
use from_seed with 32 bytes instead of 8

### DIFF
--- a/crates/fhe/src/trbfv/shamir.rs
+++ b/crates/fhe/src/trbfv/shamir.rs
@@ -5,7 +5,7 @@ use fhe_util::rng08;
 /// with the BFV parameter system.
 use num_bigint::{BigInt, RandBigInt};
 use num_traits::{One, Zero};
-use rand::{CryptoRng, Rng, RngCore, SeedableRng};
+use rand::{CryptoRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;
 
@@ -43,7 +43,18 @@ use rayon::prelude::*;
 /// assert_eq!(secret, sss.recover(&shares[0..sss.threshold +1]));
 /// }
 ///
+/// Fork a full-entropy ChaCha20 seed from the caller's RNG.
+///
+/// Used to derive independent per-task RNGs for parallel sampling without
+/// sharing the caller's RNG across threads.
+pub(crate) fn fork_seed<R: RngCore + CryptoRng>(rng: &mut R) -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    rng.fill_bytes(&mut seed);
+    seed
+}
+
 #[derive(Debug)]
+/// Shamir Secret Sharing
 pub struct ShamirSecretSharing {
     /// Threshold for reconstruction (minimum number of shares needed is threshold + 1)
     pub threshold: usize,
@@ -126,13 +137,13 @@ impl ShamirSecretSharing {
 
         // Generate seeds deterministically from the input RNG
         // This is done so clients can test using deterministic rngs
-        let seeds: Vec<u64> = (0..self.threshold).map(|_| rng.random()).collect();
+        let seeds: Vec<[u8; 32]> = (0..self.threshold).map(|_| fork_seed(rng)).collect();
 
         // Use the seeds
         let random_coefficients: Vec<BigInt> = seeds
             .into_par_iter()
             .map(|seed| {
-                let mut rng = ChaCha20Rng::seed_from_u64(seed);
+                let mut rng = ChaCha20Rng::from_seed(seed);
                 rng08::adapt(&mut rng).gen_bigint_range(&low, &high)
             })
             .collect();

--- a/crates/fhe/src/trbfv/shares.rs
+++ b/crates/fhe/src/trbfv/shares.rs
@@ -16,7 +16,7 @@ use ndarray::Array2;
 use num_bigint::BigUint;
 use num_bigint::{BigInt, ToBigInt};
 use num_traits::ToPrimitive;
-use rand::{CryptoRng, Rng, RngCore, SeedableRng};
+use rand::{CryptoRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;
 use std::convert::TryFrom;
@@ -135,7 +135,9 @@ impl ShareManager {
         let coeff_rows: Vec<_> = coefficients.outer_iter().collect();
 
         // Generate seeds deterministically from the input RNG
-        let seeds: Vec<u64> = (0..moduli.len()).map(|_| rng.random()).collect();
+        let seeds: Vec<[u8; 32]> = (0..moduli.len())
+            .map(|_| crate::trbfv::shamir::fork_seed(rng))
+            .collect();
 
         let return_vec: Result<Vec<Array2<u64>>, Error> = moduli
             .par_iter()
@@ -143,7 +145,7 @@ impl ShareManager {
             .enumerate()
             .map(|(i, (m, p))| -> Result<Array2<u64>, Error> {
                 // Get rng from seed
-                let mut rng = ChaCha20Rng::seed_from_u64(seeds[i]);
+                let mut rng = ChaCha20Rng::from_seed(seeds[i]);
 
                 // Create shamir object
                 let shamir = ShamirSecretSharing {


### PR DESCRIPTION
avoid using `[ChaCha20::from_u64_seed()](https://docs.rs/rand_core/0.10.0/rand_core/trait.SeedableRng.html#method.seed_from_u64)` for Shamir. 