### PR TITLE
fixed docs and indexing and added ZK witness tests

### DIFF
--- a/crates/fhe/src/bfv/keys/key_switching_key.rs
+++ b/crates/fhe/src/bfv/keys/key_switching_key.rs
@@ -221,7 +221,7 @@ impl KeySwitchingKey {
     /// polynomials sampled during `c0` generation.
     ///
     /// Each `errors[i]` is the small error `eᵢ` such that
-    /// `c0[i] = eᵢ − c1[i]·sk + gᵢ·from`.  The errors are returned in
+    /// `c0[i] = eᵢ − c1[i]·sk + gᵢ·from` (paper notation: `d0ᵢ = eᵢ − sk·d1ᵢ + gᵢ·r`).  The errors are returned in
     /// `NttShoup` form for consistency with `c0`.  They are needed by ZK
     /// witness-generation routines that must prove knowledge of the noise.
     pub fn new_with_c1_extended<R: RngCore + CryptoRng>(
@@ -358,16 +358,19 @@ impl KeySwitchingKey {
         c1: &[Poly<NttShoup>],
         rng: &mut R,
     ) -> Result<Vec<Poly<NttShoup>>> {
-        if c1.is_empty() {
-            return Err(Error::DefaultError("Empty number of c1's".to_string()));
-        }
-
+        let ctx0 = c1
+            .first()
+            .ok_or_else(|| Error::DefaultError("Empty number of c1's".to_string()))?
+            .ctx();
         let s = Zeroizing::new(
-            Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), c1[0].ctx(), false)?
-                .into_ntt(),
+            Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), ctx0, false)?.into_ntt(),
         );
 
-        let rns = RnsContext::new(&sk.params.moduli[..c1.len()])?;
+        let moduli_slice =
+            sk.params.moduli.get(..c1.len()).ok_or_else(|| {
+                Error::DefaultError("c1 length exceeds modulus count".to_string())
+            })?;
+        let rns = RnsContext::new(moduli_slice)?;
 
         let c0 = c1
             .iter()
@@ -407,12 +410,12 @@ impl KeySwitchingKey {
         rng: &mut R,
         log_base: usize,
     ) -> Result<Vec<Poly<NttShoup>>> {
-        if c1.is_empty() {
-            return Err(Error::DefaultError("Empty number of c1's".to_string()));
-        }
+        let ctx0 = c1
+            .first()
+            .ok_or_else(|| Error::DefaultError("Empty number of c1's".to_string()))?
+            .ctx();
         let s = Zeroizing::new(
-            Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), c1[0].ctx(), false)?
-                .into_ntt(),
+            Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), ctx0, false)?.into_ntt(),
         );
 
         let c0 = c1
@@ -450,16 +453,19 @@ impl KeySwitchingKey {
         c1: &[Poly<NttShoup>],
         rng: &mut R,
     ) -> Result<(Vec<Poly<NttShoup>>, Vec<Poly<NttShoup>>)> {
-        if c1.is_empty() {
-            return Err(Error::DefaultError("Empty number of c1's".to_string()));
-        }
-
+        let ctx0 = c1
+            .first()
+            .ok_or_else(|| Error::DefaultError("Empty number of c1's".to_string()))?
+            .ctx();
         let s = Zeroizing::new(
-            Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), c1[0].ctx(), false)?
-                .into_ntt(),
+            Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), ctx0, false)?.into_ntt(),
         );
 
-        let rns = RnsContext::new(&sk.params.moduli[..c1.len()])?;
+        let moduli_slice =
+            sk.params.moduli.get(..c1.len()).ok_or_else(|| {
+                Error::DefaultError("c1 length exceeds modulus count".to_string())
+            })?;
+        let rns = RnsContext::new(moduli_slice)?;
 
         let pairs: Vec<(Poly<NttShoup>, Poly<NttShoup>)> = c1
             .iter()
@@ -504,13 +510,12 @@ impl KeySwitchingKey {
         rng: &mut R,
         log_base: usize,
     ) -> Result<(Vec<Poly<NttShoup>>, Vec<Poly<NttShoup>>)> {
-        if c1.is_empty() {
-            return Err(Error::DefaultError("Empty number of c1's".to_string()));
-        }
-
+        let ctx0 = c1
+            .first()
+            .ok_or_else(|| Error::DefaultError("Empty number of c1's".to_string()))?
+            .ctx();
         let s = Zeroizing::new(
-            Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), c1[0].ctx(), false)?
-                .into_ntt(),
+            Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), ctx0, false)?.into_ntt(),
         );
 
         let pairs: Vec<(Poly<NttShoup>, Poly<NttShoup>)> = c1
@@ -1064,6 +1069,40 @@ mod tests {
             for (c1_1, c1_2) in ksk1.c1.iter().zip(ksk2.c1.iter()) {
                 assert_eq!(c1_1, c1_2);
             }
+        }
+        Ok(())
+    }
+
+    /// Verify `c0[i] + c1[i]·sk = eᵢ + gᵢ·from` (paper: `d0ᵢ = eᵢ − sk·d1ᵢ + gᵢ·r`).
+    #[test]
+    fn new_with_c1_extended_witness_equations() -> Result<(), Box<dyn Error>> {
+        use fhe_math::rns::RnsContext;
+        let mut rng = rng();
+        let params = BfvParameters::default_arc(6, 8);
+        let sk = SecretKey::random(&params, &mut rng);
+        let ctx = params.context_at_level(0)?;
+        let from = Poly::<PowerBasis>::small(ctx, 10, &mut rng)?;
+
+        let c1 = KeySwitchingKey::c1_from_seed(ctx, [42u8; 32], params.moduli().len());
+        let (ksk, errors) = KeySwitchingKey::new_with_c1_extended(&sk, &from, c1, 0, 0, &mut rng)?;
+
+        let sk_ntt = Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), ctx, false)
+            .map_err(crate::Error::MathError)?
+            .into_ntt();
+        let rns = RnsContext::new(&params.moduli)?;
+
+        for (i, ((c0_i, c1_i), e_i)) in ksk
+            .c0
+            .iter()
+            .zip(ksk.c1.iter())
+            .zip(errors.iter())
+            .enumerate()
+        {
+            let lhs = (&c0_i.clone().into_ntt() + &(&c1_i.clone().into_ntt() * &sk_ntt))
+                .into_power_basis();
+            let gi = rns.get_garner(i).expect("garner");
+            let rhs = (&e_i.clone().into_ntt() + &(gi * &from).into_ntt()).into_power_basis();
+            assert_eq!(lhs, rhs, "witness equation failed at row {i}");
         }
         Ok(())
     }

--- a/crates/fhe/src/lbfv/keys/relinearization_key.rs
+++ b/crates/fhe/src/lbfv/keys/relinearization_key.rs
@@ -206,8 +206,8 @@ impl LBFVRelinearizationKey {
     ///
     /// Returns `(ksk_r_to_s, ksk_s_to_r, r, errors_d0, errors_d2)` where:
     /// - `r` is the ephemeral `SecretKey`; auto-zeroized when dropped.
-    /// - `errors_d0[i]` is the small error `eᵢ` such that `d0ᵢ = eᵢ − sk·d1ᵢ + rᵢ·g`.
-    /// - `errors_d2[i]` is the small error `eᵢ` such that `d2ᵢ = eᵢ + r·aᵢ + skᵢ·g`.
+    /// - `errors_d0[i]` is the small error `eᵢ` such that `d0ᵢ = eᵢ − sk·d1ᵢ + gᵢ·r`.
+    /// - `errors_d2[i]` is the small error `eᵢ` such that `d2ᵢ = eᵢ + r·aᵢ + gᵢ·sk`.
     #[allow(clippy::type_complexity)]
     pub(crate) fn generate_components_with_polys_extended<R: RngCore + CryptoRng>(
         sk: &SecretKey,
@@ -519,7 +519,16 @@ impl LBFVRelinearizationKey {
     /// * `Err` if the number of moduli in the ciphertext context is not equal
     ///   to the number of polynomials in `b_vec`, which should be equal to "l".
     pub fn l(&self) -> Result<usize> {
-        if self.ksk_r_to_s.params.max_level() + 1 - self.ciphertext_level() != self.b_vec.len() {
+        let expected = self
+            .ksk_r_to_s
+            .params
+            .max_level()
+            .checked_add(1)
+            .and_then(|v| v.checked_sub(self.ciphertext_level()))
+            .ok_or_else(|| {
+                Error::DefaultError("ciphertext_level exceeds max_level in l()".to_string())
+            })?;
+        if expected != self.b_vec.len() {
             return Err(Error::DefaultError("'l' is not consistent.".to_string()));
         }
         Ok(self.b_vec.len())
@@ -1009,6 +1018,81 @@ mod tests {
             Vec::<u64>::try_decode(&sk.try_decrypt(&explicit_product)?, Encoding::poly())?[0],
             9
         );
+
+        Ok(())
+    }
+
+    /// Verify per-row KSK equations from the paper for `generate_components_with_polys_extended`:
+    /// - `d0ᵢ + sk·d1ᵢ = e0ᵢ + gᵢ·r`  (ksk_r_to_s)
+    /// - `d2ᵢ − r·aᵢ = e2ᵢ + gᵢ·sk`   (ksk_s_to_r, using neg_r so sign cancels)
+    #[test]
+    fn generate_components_extended_witness_equations() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::bfv::KeySwitchingKey;
+        use fhe_math::rns::RnsContext;
+        use fhe_math::rq::traits::TryConvertFrom as TryConvertFromPoly;
+
+        let mut rng = rng();
+        let params = BfvParameters::default_arc(6, 8);
+        let sk = SecretKey::random(&params, &mut rng);
+        let ctx = params.context_at_level(0)?;
+
+        let d1_polys = KeySwitchingKey::c1_from_seed(ctx, [11u8; 32], params.moduli().len());
+        let a_polys = KeySwitchingKey::c1_from_seed(ctx, [22u8; 32], params.moduli().len());
+
+        let (ksk_r_to_s, ksk_s_to_r, r, errors_d0, errors_d2) =
+            LBFVRelinearizationKey::generate_components_with_polys_extended(
+                &sk,
+                d1_polys.clone(),
+                a_polys.clone(),
+                0,
+                0,
+                &mut rng,
+            )?;
+
+        let rns = RnsContext::new(&params.moduli)?;
+
+        let sk_ntt =
+            Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), ctx, false)?.into_ntt();
+        let r_pb = Poly::<PowerBasis>::try_convert_from(r.coeffs.as_ref(), ctx, false)?;
+        let sk_pb = Poly::<PowerBasis>::try_convert_from(sk.coeffs.as_ref(), ctx, false)?;
+
+        // d0ᵢ + sk·d1ᵢ = e0ᵢ + gᵢ·r
+        for (i, ((d0_i, d1_i), e0_i)) in ksk_r_to_s
+            .c0
+            .iter()
+            .zip(ksk_r_to_s.c1.iter())
+            .zip(errors_d0.iter())
+            .enumerate()
+        {
+            let lhs = (&d0_i.clone().into_ntt() + &(&d1_i.clone().into_ntt() * &sk_ntt))
+                .into_power_basis();
+            let gi = rns.get_garner(i).expect("garner");
+            let rhs = (&e0_i.clone().into_ntt() + &(gi * &r_pb).into_ntt()).into_power_basis();
+            assert_eq!(lhs, rhs, "d0 witness equation failed at row {i}");
+        }
+
+        // ksk_s_to_r was built with neg_r = −r as the "sk" argument.
+        // KSK invariant: c0ᵢ + c1ᵢ·(encrypting_key) = eᵢ + gᵢ·(from_key)
+        // Here encrypting_key = neg_r, from_key = sk, so: d2ᵢ + aᵢ·(−r) = e2ᵢ + gᵢ·sk
+        // Rearranged (paper form):  d2ᵢ = e2ᵢ + r·aᵢ + gᵢ·sk  ✓
+        let mut neg_r_coeffs = r.coeffs.clone();
+        neg_r_coeffs.iter_mut().for_each(|c| *c = c.wrapping_neg());
+        let neg_r_pb = Poly::<PowerBasis>::try_convert_from(neg_r_coeffs.as_ref(), ctx, false)?;
+        let neg_r_ntt = neg_r_pb.into_ntt();
+
+        for (i, ((d2_i, a_i), e2_i)) in ksk_s_to_r
+            .c0
+            .iter()
+            .zip(ksk_s_to_r.c1.iter())
+            .zip(errors_d2.iter())
+            .enumerate()
+        {
+            let lhs = (&d2_i.clone().into_ntt() + &(&a_i.clone().into_ntt() * &neg_r_ntt))
+                .into_power_basis();
+            let gi = rns.get_garner(i).expect("garner");
+            let rhs = (&e2_i.clone().into_ntt() + &(gi * &sk_pb).into_ntt()).into_power_basis();
+            assert_eq!(lhs, rhs, "d2 witness equation failed at row {i}");
+        }
 
         Ok(())
     }

--- a/crates/fhe/src/trlbfv/relin_key_share.rs
+++ b/crates/fhe/src/trlbfv/relin_key_share.rs
@@ -19,9 +19,9 @@ pub struct RlkWitness {
     /// Ephemeral randomness key used during RLK generation.
     /// Auto-zeroized when dropped.
     pub r: Zeroizing<SecretKey>,
-    /// Per-row errors from `ksk_r_to_s`: `eᵢ` such that `d0ᵢ = eᵢ − sk·d1ᵢ + rᵢ·g`.
+    /// Per-row errors from `ksk_r_to_s`: `eᵢ` such that `d0ᵢ = eᵢ − sk·d1ᵢ + gᵢ·r`.
     pub errors_d0: Vec<Poly<NttShoup>>,
-    /// Per-row errors from `ksk_s_to_r`: `eᵢ` such that `d2ᵢ = eᵢ + r·aᵢ + skᵢ·g`.
+    /// Per-row errors from `ksk_s_to_r`: `eᵢ` such that `d2ᵢ = eᵢ + r·aᵢ + gᵢ·sk`.
     pub errors_d2: Vec<Poly<NttShoup>>,
 }
 


### PR DESCRIPTION
## Summary

- **Doc notation**: corrected subscript placement in `relin_key_share.rs`,
  `relinearization_key.rs`, and `key_switching_key.rs` — `rᵢ·g` / `skᵢ·g`
  → `gᵢ·r` / `gᵢ·sk` to match paper notation

- **Safe arithmetic in `l()`**: replaced unchecked `max_level() + 1 - ciphertext_level()`
  with `checked_add(1).and_then(checked_sub).ok_or_else(...)` in `relinearization_key.rs`

- **Indexing fixes**: replaced `c1[0]` with `.first().ok_or_else(...)` and
  `&moduli[..c1.len()]` with `.get(..c1.len()).ok_or_else(...)` across all four
  private generate functions in `key_switching_key.rs` to satisfy the workspace
  `clippy::indexing_slicing` deny

- **ZK witness equation tests**: added two tests verifying the paper equations hold exactly
  - `new_with_c1_extended_witness_equations`:
    checks `c0ᵢ + c1ᵢ·sk = eᵢ + gᵢ·from`
  - `generate_components_extended_witness_equations`:
    checks `d0ᵢ + sk·d1ᵢ = e0ᵢ + gᵢ·r` and `d2ᵢ + aᵢ·(−r) = e2ᵢ + gᵢ·sk`