### PR TITLE
Rename TRBFV share-count error helper

### DIFF
--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -38,7 +38,7 @@ The agent set (see `AGENTS.md` → **Development workflow**):
 ## The Flow
 
 ```
-Issue / new request → decide → architect (subagent) produces codebase-level design plan → [user approves]
+Issue / new request → decide → [straightforward bypass → implementer] or [architect (subagent) produces codebase-level design plan → user approves]
                                     ↓
         implementer (subagent) derives implementation plan + implements → [tests + clippy green]
                                     ↓
@@ -66,11 +66,11 @@ Take the user's request. It is either:
 - **An issue to work** — a bug report, task, or GitHub issue. If it is a bug with an unclear root cause, dispatch `reviewer` in triage mode first: it returns a **Bug Triage Report**. If it is a clear feature or task, go straight to planning.
 - **A new request to create** — a feature or change the user wants. Go straight to planning.
 
-Then decide: does this need `architect`? The default is yes for any non-trivial work — the architect produces the codebase-level design plan. Only bypass it for changes that are already fully specified end-to-end and verified (e.g. a one-line harness typo fix), and even then ask the user first.
+Then decide: does this need `architect`? The default is yes for any non-trivial work — the architect produces the codebase-level design plan. Bypass it for a straightforward task when the requested change is fully specified end-to-end, localized, behaviorally obvious, and has no meaningful architectural, API, security, or mathematical choices (for example, a helper rename with an unchanged error variant and message). State the bypass rationale and dispatch the implementer directly; do not create a design plan or ask for design approval. If there is uncertainty about scope or impact, use the architect.
 
 ### 2. Planning — dispatch `architect`
 
-1. **Tell the user:** "I'll dispatch the `architect` subagent to produce a design plan."
+1. **Tell the user:** "I'll dispatch the `architect` subagent to produce a design plan." For an approved straightforward-task bypass, instead state that the task meets the bypass criteria and proceed directly to implementation.
 2. **Dispatch `architect`** via the task tool with the issue/request (plus any triage report). It explores the codebase, may ask the developer clarifying questions via the `question` tool, and returns a codebase-level design plan in a `DESIGN_START`/`DESIGN_END` marker block, persisting it to `.plans/<slug>.md` itself. **You never write plan files.**
 3. **Present the returned design plan** to the user and ask: "Does this look right?"
 4. If not approved → ask what to change, then resume the same `architect` task with its `task_id` and the feedback. If no `task_id` is available, dispatch a new `architect` with the design and feedback.
@@ -129,7 +129,7 @@ This applies the same Touch → update reflex to the scaffolding itself: a chang
 | "I'll just commit this"        | No commits without explicit consent.                                                                |
 | "I'll persist the plan myself" | Never write plan files — `architect` owns `.plans/*`.                                                |
 | "The subagent will handle it"  | You are the gate. Verify before proceeding.                                                         |
-| "This is too simple to plan"   | Default is always planning via `architect`; bypass only with user approval.                         |
+| "This is too simple to plan"   | Bypass `architect` only when the task is fully specified, localized, behaviorally obvious, and has no meaningful architectural, API, security, or mathematical choices; otherwise plan normally. |
 | "Silently loop on review fixes"| Always present the report, recommend a path, let the user decide.                                   |
 
 ## Flow Retrospective

--- a/.rules/harness.md
+++ b/.rules/harness.md
@@ -47,6 +47,10 @@ Architecture and review agents are read-only (`edit: deny`). `implementer` edits
 
 Bash permissions use an explicit deny-list for destructive actions. The broad rule comes first and narrower rules come later because OpenCode applies the last matching rule. All custom agents repeat the deny-list because agent permissions are appended after project permissions.
 
+### Workflow selection
+
+The orchestrator may bypass the architect for a straightforward task only when the request is fully specified end-to-end, localized, behaviorally obvious, and introduces no meaningful architectural, API, security, or mathematical choice. The bypass rationale must be stated, implementation still goes through the implementer, and normal verification and review gates remain unchanged. Unclear or broader work must use the architect.
+
 ### OpenCode config lives in `.opencode/opencode.json`
 
 OpenCode declares MCP servers and permissions under `.opencode/opencode.json`. `AGENTS.md` is auto-loaded from the project root by OpenCode; rules load on demand via the Touch → update table, not all upfront.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ At the start of each agent session, run `git rev-parse --show-toplevel` and use 
 
 ## Development workflow
 
-For any task, start with the **`orchestrator`** agent — it is the sole entry point. It decides when to run `architect` (codebase-level design plan, from an existing issue or a new request), dispatches `implementer` (which derives the detailed implementation plan and implements it), runs `reviewer` (review only on explicit user go-ahead, triage for bugs), and takes care of harness updates. `orchestrator` always operates on the current branch — it never creates or switches branches.
+For any task, start with the **`orchestrator`** agent — it is the sole entry point. It decides whether the task needs an `architect` design (required for non-trivial work; straightforward, fully specified tasks may bypass it), dispatches `implementer` (which derives the detailed implementation plan and implements it), runs `reviewer` (review only on explicit user go-ahead, triage for bugs), and takes care of harness updates. `orchestrator` always operates on the current branch — it never creates or switches branches.
 
 The agent set:
 

--- a/crates/fhe/src/trbfv/errors.rs
+++ b/crates/fhe/src/trbfv/errors.rs
@@ -16,9 +16,9 @@ impl Error {
         }
     }
 
-    /// Create an insufficient shares error.
+    /// Create a share count mismatch error.
     #[must_use]
-    pub fn insufficient_shares(got: usize, required: usize) -> Self {
+    pub fn share_count_mismatch(got: usize, required: usize) -> Self {
         Error::Threshold(ThresholdError::ShareCountMismatch {
             actual: got,
             expected: required,
@@ -147,7 +147,7 @@ mod tests {
             })
         ));
 
-        let error = Error::insufficient_shares(2, 3);
+        let error = Error::share_count_mismatch(2, 3);
         assert!(matches!(
             error,
             Error::Threshold(ThresholdError::ShareCountMismatch {

--- a/crates/fhe/src/trbfv/shamir.rs
+++ b/crates/fhe/src/trbfv/shamir.rs
@@ -186,7 +186,10 @@ impl ShamirSecretSharing {
     /// (e.g., duplicate share indices).
     pub fn recover(&self, shares: &[(usize, BigInt)]) -> Result<BigInt, Error> {
         if shares.len() != self.threshold + 1 {
-            return Err(Error::insufficient_shares(shares.len(), self.threshold + 1));
+            return Err(Error::share_count_mismatch(
+                shares.len(),
+                self.threshold + 1,
+            ));
         }
         let (xs, ys): (Vec<usize>, Vec<BigInt>) = shares.iter().cloned().unzip();
         let result = self.lagrange_interpolation(Zero::zero(), xs, ys)?;

--- a/crates/fhe/src/trbfv/shares.rs
+++ b/crates/fhe/src/trbfv/shares.rs
@@ -236,10 +236,10 @@ impl ShareManager {
         sk_sss_collected: &[Array2<u64>], // collected sk sss shares from other parties
     ) -> Result<Poly<PowerBasis>, Error> {
         if sk_sss_collected.is_empty() {
-            return Err(Error::insufficient_shares(0, 1));
+            return Err(Error::share_count_mismatch(0, 1));
         }
         if sk_sss_collected.len() > self.n {
-            return Err(Error::insufficient_shares(sk_sss_collected.len(), self.n));
+            return Err(Error::share_count_mismatch(sk_sss_collected.len(), self.n));
         }
         let expected_shape = (self.params.moduli().len(), self.params.degree());
         for (party_idx, item) in sk_sss_collected.iter().enumerate() {
@@ -394,14 +394,14 @@ impl ShareManager {
         // exactness (rather than truncating extras) avoids silently depending
         // on the order of the provided shares.
         if d_share_polys.len() != self.threshold + 1 {
-            return Err(Error::insufficient_shares(
+            return Err(Error::share_count_mismatch(
                 d_share_polys.len(),
                 self.threshold + 1,
             ));
         }
         // The number of reconstructing parties must match the provided shares
         if reconstructing_parties.len() != d_share_polys.len() {
-            return Err(Error::insufficient_shares(
+            return Err(Error::share_count_mismatch(
                 reconstructing_parties.len(),
                 d_share_polys.len(),
             ));


### PR DESCRIPTION
## Summary
- rename the misleading `insufficient_shares` helper to `share_count_mismatch`
- preserve the existing neutral `ShareCountMismatch` error and message
- document the straightforward-task architect bypass in the harness

## Verification
- `cargo fmt --all`
- focused TRBFV tests
- `cargo test --release --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Closes #117