### PR TITLE
Enforce ShareManager threshold validation; retune trbfv mul examples (#113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ proptest-regressions/
 # AI harness
 .claude/settings.local.json
 .plans
+.worktrees

--- a/.rules/cryptography.md
+++ b/.rules/cryptography.md
@@ -47,8 +47,9 @@ ZK proof generation and verification, commitments, proof aggregation, and on-cha
 4.5. Distributed RLK error accounts for `|S| * B_e` (and aggregated noise grows ~`|S|·σ²`) or an explicit aggregate bound, and `accepted_participant_count` is included in smudging recursion.
 4.6. Smudging coefficients are uniform in `[-B_sm, B_sm]`; `B_sm` and `B_e` are coefficient bounds, not variances.
 4.7. Decryption-share APIs state whether they accept local noise, a Shamir joint-noise share, or reconstructed joint noise.
-4.8. `ShareManager::new` requires `n < min modulus` so the Shamir evaluation points `1..=n` are distinct units modulo every modulus.
+4.8. `ShareManager::new` enforces the trBFV threshold invariants (`n >= 3`, `T = (n - 1) / 2`) via `validate_threshold_config`, rejecting degree-0 sharings and configurations that break privacy or honest-party reconstruction, and requires `n < min modulus` so the Shamir evaluation points `1..=n` are distinct units modulo every modulus.
 4.9. Threshold decryption follows the level-zero contract: `decryption_share` rejects 3-component (unrelinearized) ciphertexts, and `decrypt_from_shares` requires a u64 plaintext modulus.
+4.10. Every secure example/benchmark preset proves smudging feasibility for its declared full configuration (moduli, `n`, `lambda`, `m`, `mult_depth`, and the accepted participant set) through the bound calculator — a preset-level feasibility test pins the exact constants the example runs with. An infeasible preset is a parameter/correctness regression to retune, not a runtime panic to unwrap (issue #113).
 
 **MBFV**
 

--- a/.rules/testing.md
+++ b/.rules/testing.md
@@ -17,6 +17,7 @@ Release-mode tests, focused verification, property tests, criterion benchmarks, 
 9. Smudging tests cover the CBD branch (`v <= 16`, bound `2 * error1_variance`), the uniform branch (`variance_to_uniform_bound`, smallest `B` with `B(B+1)/3 >= v`), depth monotonicity at 0/1/2, accepted participant counts 0/intermediate/`n`, and default `n` behavior.
 10. Strict Delta tests reject equality `2 * (B_C + n * B_sm) == Delta` and accept one unit below; round trips alone do not establish smudging.
 11. Threshold E2E uses odd `n`, depth at least one, `threshold + 1` shares, and confirms fewer shares fail.
+12. Preset-level smudging feasibility tests pin each secure example's exact configuration (moduli, `n`, `lambda`, `m`, `mult_depth`, accepted participant count) and assert `SmudgingBoundCalculator::calculate_sm_bound` returns `Ok`. Strict-bound unit tests alone did not catch the infeasible multiplication-example presets that panicked at runtime (issue #113); retuning a preset must flip these tests from RED to GREEN.
 
 ## Evidence / tests
 

--- a/crates/fhe/examples/trbfv_mul_bfv_share.rs
+++ b/crates/fhe/examples/trbfv_mul_bfv_share.rs
@@ -8,13 +8,16 @@
 //
 // Two BFV parameter sets:
 //
-//   First set  (computation) — n=5, z=3, k=1000, d=16384, 4×61-bit moduli, λ=40.
-//              Correctness: log₂(B_C after mult) = 187.5 < log₂(Δ) = 234.0  ✓
+//   First set  (computation) — n=19, t=9, k=1000, d=16384, 5×54-bit moduli, λ=38.
+//              Smudging feasibility for this exact preset is pinned by the
+//              `preset_smudging_feasible` test below (issue #113).
 //
-//   Second set (share encryption) — k = q[1] of first set ≈ 2^61, d=16384,
+//   Second set (share encryption) — k = largest trBFV modulus ≈ 2^54, d=16384,
 //              2×62-bit moduli. Each Shamir share value lies in [0, q_i) ⊆ [0, k),
 //              so it encodes directly as a BFV plaintext.
-//              BFV decrypt is correct because k ≈ 2^61 < q₀/2 ≈ 2^61.9999  ✓
+//              BFV decrypt rounds t·v/Q, so exact recovery needs the error to
+//              stay below Δ/2 ≈ Q/(2k), not merely below Q/2. A fresh-noise
+//              sanity check for this preset leaves ≈ 58 bits of Δ/2 headroom.
 //
 // Protocol:
 //  1. Each party generates: an l-BFV pk share, an l-BFV RLK share, Shamir shares of
@@ -23,8 +26,9 @@
 //     shares for every receiver under the receiver's share-encryption key.
 //  3. Each receiver decrypts and aggregates the collected shares to reconstruct
 //     its Lagrange evaluation point of the combined secret key SK = Σ sk_j.
-//  4. Two values are encrypted under the aggregated l-BFV pk, multiplied and
-//     relinearized using the aggregated RLK, then threshold-decrypted by t+1 parties.
+//  4. Four values are encrypted under the aggregated l-BFV pk, multiplied in
+//     three chained multiplications with relinearization after each, then
+//     threshold-decrypted by t+1 parties.
 
 #![allow(clippy::indexing_slicing, missing_docs)]
 
@@ -51,6 +55,27 @@ use rayon::prelude::*;
 use std::time::Instant;
 use util::timeit::timeit;
 
+// Preset parameter set for this example. The smudging feasibility of the exact
+// trBFV configuration below (degree, plaintext, moduli, n, lambda) is pinned by
+// the `preset_smudging_feasible` test in this file — see issue #113.
+// Caveat: this preset is verified consistent with the implemented noise/smudging
+// bounds (correctness), but has not been independently checked against an RLWE
+// estimator for computational security.
+const DEGREE: usize = 16384;
+const PLAINTEXT_MODULUS_TRBFV: u64 = 1_000;
+const MODULI_TRBFV: [u64; 5] = [
+    0x003fffffffef8001, // 18014398508400641 (largest)
+    0x003fffffffeb8001, // 18014398508138497
+    0x003fffffffe38001, // 18014398507614209
+    0x003fffffffdd8001, // 18014398507220993
+    0x003fffffffd78001, // 18014398506827777
+];
+const PLAINTEXT_MODULUS_SHARE_ENC: u64 = MODULI_TRBFV[0]; // largest trBFV modulus
+const MODULI_SHARE_ENC: [u64; 2] = [0x3fffffffffd78001, 0x3fffffffffe80001];
+const DEFAULT_NUM_PARTIES: usize = 19;
+const DEFAULT_THRESHOLD: usize = 9;
+const DEFAULT_LAMBDA: usize = 38;
+
 fn print_notice_and_exit(error: Option<String>) {
     println!(
         "{} Threshold BFV multiplication with encrypted share transport",
@@ -61,7 +86,7 @@ fn print_notice_and_exit(error: Option<String>) {
         style("     usage:").magenta().bold()
     );
     println!(
-        "{} T ≤ (N-1)/2, N ≥ 1, L ≥ {}. Paper-conforming robustness requires odd N (N = 2t + 1);",
+        "{} T = (N-1)/2, N ≥ 3, L ≥ {}. Paper-conforming robustness requires odd N (N = 2t + 1);",
         style("constraints:").magenta().bold(),
         fhe::trbfv::MIN_SECURE_LAMBDA,
     );
@@ -77,15 +102,10 @@ fn print_notice_and_exit(error: Option<String>) {
 
 fn main() -> Result<(), Box<dyn Error>> {
     // ── First BFV parameter set (threshold computation) ──────────────────────
-    // n=5, z=3, k=1000, λ=40, σ²=10. Four 61-bit NTT primes, each ≡ 1 mod 32768. ✓
-    let degree = 16384usize;
-    let plaintext_modulus_trbfv: u64 = 1_000;
-    let moduli_trbfv = [
-        0x1fffffffffe10001u64, // q[1] = 2305843009211662337
-        0x1fffffffffe00001,    // q[2] = 2305843009210613761
-        0x1fffffffffdd0001,    // q[3] = 2305843009196982273
-        0x1fffffffffd08001,    // q[4] = 2305843009177763841
-    ];
+    // n=19, t=9, k=1000, λ=38, σ²=10. Five 54-bit NTT primes, each ≡ 1 mod 32768. ✓
+    let degree = DEGREE;
+    let plaintext_modulus_trbfv = PLAINTEXT_MODULUS_TRBFV;
+    let moduli_trbfv = MODULI_TRBFV;
 
     println!("Building trBFV parameters (first set)...");
     let params_trbfv: Arc<bfv::BfvParameters> = timeit!(
@@ -95,7 +115,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             .set_plaintext_modulus(plaintext_modulus_trbfv)
             .set_moduli(&moduli_trbfv)
             .set_variance(10)
-            // Var(e_1) from the parameter tool: n=5, z=3, λ=40.
+            // Var(e_1) from the earlier parameter-tool design point, retained
+            // unchanged; the `preset_smudging_feasible` test pins the feasibility
+            // of this configuration.
             .set_error1_variance_str("4326914048779023023775413607683413333")?
             .build_arc()?
     );
@@ -110,11 +132,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // ── Second BFV parameter set (share encryption) ───────────────────────────
-    // Plaintext modulus = q[1] of the first set ≈ 2^61. All Shamir share values
-    // lie in [0, q_i) ⊆ [0, q[1]) = [0, k), so they fit as BFV plaintexts.
-    // Two 62-bit NTT primes (≡ 1 mod 32768). Correctness: k ≈ 2^61 < q₀/2 ≈ 2^61.0000003 ✓
-    let plaintext_modulus_share_enc: u64 = moduli_trbfv[0]; // = q[1]
-    let moduli_share_enc = [0x3fffffffffd78001u64, 0x3fffffffffe80001];
+    // Plaintext modulus = largest trBFV modulus ≈ 2^54, so every Shamir share
+    // value (each in [0, q_i) ⊆ [0, k)) encodes directly as a BFV plaintext.
+    // Two 62-bit NTT primes (≡ 1 mod 32768), coprime to the plaintext modulus.
+    // Correctness: BFV decrypt rounds t·v/Q, which recovers the message exactly
+    // iff the error stays below Δ/2 ≈ Q/(2k); a fresh-noise sanity check for
+    // this preset leaves ≈ 58 bits of Δ/2 headroom.
+    let plaintext_modulus_share_enc = PLAINTEXT_MODULUS_SHARE_ENC;
+    let moduli_share_enc = MODULI_SHARE_ENC;
     println!("\nBuilding share-encryption parameters (second set)...");
     let params_share_enc: Arc<bfv::BfvParameters> = timeit!(
         "Parameters generation (share enc)",
@@ -142,10 +167,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         print_notice_and_exit(None)
     }
 
-    // Defaults: n=5 keeps the example fast; the params are correct for n up to 20.
-    let mut num_parties = 5usize;
-    let mut threshold = 2usize;
-    let mut lambda = 40usize;
+    // Defaults: n=19 (odd, paper-conforming 2t+1) tuned to this preset; the
+    // `preset_smudging_feasible` test pins smudging feasibility for this exact
+    // configuration (issue #113).
+    let mut num_parties = DEFAULT_NUM_PARTIES;
+    let mut threshold = DEFAULT_THRESHOLD;
+    let mut lambda = DEFAULT_LAMBDA;
 
     for arg in &args {
         if arg.starts_with("--num_parties") {
@@ -174,21 +201,23 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    if num_parties == 0 || lambda == 0 {
-        print_notice_and_exit(Some("Party count and lambda must be nonzero".to_string()))
-    }
-    if threshold > (num_parties - 1) / 2 {
+    if num_parties < 3 || lambda == 0 {
         print_notice_and_exit(Some(
-            "Threshold must be at most (num_parties - 1) / 2".to_string(),
+            "Party count must be at least 3 and lambda must be nonzero".to_string(),
+        ))
+    }
+    if threshold != (num_parties - 1) / 2 {
+        print_notice_and_exit(Some(
+            "Threshold must be exactly (num_parties - 1) / 2: maximal corruption tolerance with honest-majority reconstruction".to_string(),
         ))
     }
 
-    // λ=40 is the design point of this parameter set (≥ fhe::trbfv::MIN_SECURE_LAMBDA=35).
+    // λ=38 is the design point of this preset (≥ fhe::trbfv::MIN_SECURE_LAMBDA=35).
     let security = Lambda::secure(lambda)?;
     let mut rng = rand::rng();
 
     println!("\n# Threshold BFV multiplication");
-    println!("  num_parties       = {num_parties}  (params: n=5, k=1000, z=3, λ=40)");
+    println!("  num_parties       = {num_parties}  (params: n=19, k=1000, depth=3, λ=38)");
     println!("  threshold         = {threshold}");
     println!("  lambda            = {lambda}  (secure, >= fhe::trbfv::MIN_SECURE_LAMBDA)");
     println!(
@@ -221,54 +250,48 @@ fn main() -> Result<(), Box<dyn Error>> {
         pk_share_enc: PublicKey,
     }
 
-    let trbfv: TRBFV = TRBFV::new(num_parties, threshold, params_trbfv.clone()).unwrap();
+    let trbfv: TRBFV = TRBFV::new(num_parties, threshold, params_trbfv.clone())?;
     let num_moduli = params_trbfv.moduli().len();
 
     println!("\n💻 Available CPU cores: {}", rayon::current_num_threads());
     let mut parties: Vec<Party> = timeit!("Party setup (parallel)", {
         (0..num_parties)
             .into_par_iter()
-            .map(|i| {
+            .map(|i| -> Result<Party, fhe::Error> {
                 let mut rng = rand::rng();
 
                 let sk_share = SecretKey::random(&params_trbfv, &mut rng);
 
                 let mut share_manager =
-                    ShareManager::new(num_parties, threshold, params_trbfv.clone()).unwrap();
-                let sk_poly = share_manager
-                    .coeffs_to_poly_level0(sk_share.coeffs.clone().as_ref())
-                    .unwrap();
+                    ShareManager::new(num_parties, threshold, params_trbfv.clone())?;
+                let sk_poly =
+                    share_manager.coeffs_to_poly_level0(sk_share.coeffs.clone().as_ref())?;
 
-                let sk_sss = trbfv
-                    .generate_secret_shares_from_poly(sk_poly, &mut rng)
-                    .unwrap();
+                let sk_sss = trbfv.generate_secret_shares_from_poly(sk_poly, &mut rng)?;
 
                 // Smudging noise shares (m=1 ciphertext, depth=3 multiplications,
-                // accepted l-BFV participant count = num_parties).
-                let esi_coeffs = trbfv
-                    .generate_smudging_error_with_participant_count(
-                        1,
-                        3,
-                        num_parties,
-                        security,
-                        &mut rng,
-                    )
-                    .unwrap();
-                let esi_poly = share_manager.bigints_to_poly(&esi_coeffs).unwrap();
-                let esi_sss = share_manager
-                    .generate_secret_shares_from_poly(esi_poly, &mut rng)
-                    .unwrap();
+                // accepted l-BFV participant count = num_parties). An infeasible
+                // configuration is propagated out of main (issue #113) rather than
+                // panicking inside the Rayon worker.
+                let esi_coeffs = trbfv.generate_smudging_error_with_participant_count(
+                    1,
+                    3,
+                    num_parties,
+                    security,
+                    &mut rng,
+                )?;
+                let esi_poly = share_manager.bigints_to_poly(&esi_coeffs)?;
+                let esi_sss = share_manager.generate_secret_shares_from_poly(esi_poly, &mut rng)?;
 
                 // l-BFV PK contribution (shared crp_a, same a_j across all parties).
                 let lbfv_binding =
-                    ContributionBinding::new(lbfv_participant_set.clone(), (i + 1) as u32).unwrap();
+                    ContributionBinding::new(lbfv_participant_set.clone(), (i + 1) as u32)?;
                 let pk_lbfv_share = PublicKeyShare::contribute_with_crp_and_binding(
                     &sk_share,
                     &crp_a,
                     lbfv_binding.clone(),
                     &mut rng,
-                )
-                .unwrap();
+                )?;
 
                 // l-BFV RLK share for SK = Σ sk_j.
                 let rlk_share = RelinKeyShare::contribution_with_crp_and_binding(
@@ -279,15 +302,14 @@ fn main() -> Result<(), Box<dyn Error>> {
                     0,
                     0,
                     &mut rng,
-                )
-                .unwrap();
+                )?;
 
                 // Share-encryption key pair under the second parameter set.
                 let sk_share_enc = SecretKey::random(&params_share_enc, &mut rng);
                 let pk_share_enc = PublicKey::new(&sk_share_enc, &mut rng);
 
-                let ctx0 = params_trbfv.context_at_level(0).unwrap();
-                Party {
+                let ctx0 = params_trbfv.context_at_level(0)?;
+                Ok(Party {
                     sk_sss,
                     esi_sss,
                     sk_sss_collected: Vec::with_capacity(num_parties),
@@ -299,9 +321,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                     rlk_share,
                     sk_share_enc,
                     pk_share_enc,
-                }
+                })
             })
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?
     });
 
     // ── Distributed pk + RLK aggregation ─────────────────────────────────────
@@ -322,8 +344,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     // ── Share encryption and transmission ─────────────────────────────────────
     // Each sender BFV-encrypts the share row it owes to each receiver under that
     // receiver's share-encryption public key (second parameter set). This is safe:
-    //   • k = q[1] ≥ q_i for all i → share values ∈ [0, q_i) ⊆ [0, k)
-    //   • k ≈ 2^57 < q₀/2 ≈ 2^59  → BFV decrypt is algebraically exact
+    //   • k = largest trBFV modulus ≥ q_i for all i → share values ∈ [0, q_i) ⊆ [0, k)
+    //   • BFV decrypt rounds t·v/Q: exact recovery needs the error below
+    //     Δ/2 ≈ Q/(2k), not merely below Q/2 — fresh noise leaves ≈ 58 bits
+    //     of Δ/2 headroom for this preset
     //
     // encrypted_shares[sender][receiver] = (Vec<Ciphertext>, Vec<Ciphertext>)
     //   first  vec: one ciphertext per modulus for the sk share row
@@ -493,4 +517,48 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fhe::trbfv::{SmudgingBoundCalculator, SmudgingBoundCalculatorConfig};
+
+    /// The exact trBFV preset this example runs with (degree, plaintext modulus,
+    /// moduli, n = `DEFAULT_NUM_PARTIES`, lambda = `DEFAULT_LAMBDA`, one
+    /// ciphertext, three chained multiplications, all parties accepted into the
+    /// l-BFV relinearization set) must yield a feasible smudging bound.
+    ///
+    /// Regression guard for issue #113: this preset was previously infeasible and
+    /// the examples panicked inside Rayon worker closures instead of reporting the
+    /// `SmudgingBoundInfeasible` error.
+    #[test]
+    fn preset_smudging_feasible() {
+        let params = bfv::BfvParametersBuilder::new()
+            .set_degree(DEGREE)
+            .set_plaintext_modulus(PLAINTEXT_MODULUS_TRBFV)
+            .set_moduli(&MODULI_TRBFV)
+            .set_variance(10)
+            .set_error1_variance_str("4326914048779023023775413607683413333")
+            .unwrap()
+            .build_arc()
+            .unwrap();
+
+        let config = SmudgingBoundCalculatorConfig::new_multiplicative(
+            params,
+            DEFAULT_NUM_PARTIES,
+            1, // m: a single ciphertext, as in the example
+            3, // mult_depth: three chained multiplications, as in the example
+            Lambda::secure(DEFAULT_LAMBDA).unwrap(),
+        )
+        .unwrap();
+        let bound = SmudgingBoundCalculator::new(config)
+            .with_accepted_participant_count(DEFAULT_NUM_PARTIES)
+            .calculate_sm_bound();
+        assert!(
+            bound.is_ok(),
+            "the preset trBFV configuration must be smudging-feasible, got: {}",
+            bound.unwrap_err()
+        );
+    }
 }

--- a/crates/fhe/examples/trbfv_mul_bfv_share_binding.rs
+++ b/crates/fhe/examples/trbfv_mul_bfv_share_binding.rs
@@ -2,13 +2,16 @@
 //
 // Two BFV parameter sets:
 //
-//   First set  (computation) — n=5, z=3, k=1000, d=16384, 4×61-bit moduli, λ=40.
-//              Correctness: log₂(B_C after mult) = 187.5 < log₂(Δ) = 234.0  ✓
+//   First set  (computation) — n=19, t=9, k=1000, d=16384, 5×54-bit moduli, λ=38.
+//              Smudging feasibility for this exact preset is pinned by the
+//              `preset_smudging_feasible` test below (issue #113).
 //
-//   Second set (share encryption) — k = q[1] of first set ≈ 2^61, d=16384,
+//   Second set (share encryption) — k = largest trBFV modulus ≈ 2^54, d=16384,
 //              2×62-bit moduli. Each Shamir share value lies in [0, q_i) ⊆ [0, k),
 //              so it encodes directly as a BFV plaintext.
-//              BFV decrypt is correct because k ≈ 2^61 < q₀/2 ≈ 2^61.9999  ✓
+//              BFV decrypt rounds t·v/Q, so exact recovery needs the error to
+//              stay below Δ/2 ≈ Q/(2k), not merely below Q/2. A fresh-noise
+//              sanity check for this preset leaves ≈ 58 bits of Δ/2 headroom.
 //
 // Protocol:
 //  1. Each party generates: trBFV key share, Shamir shares of sk and smudging error,
@@ -17,8 +20,9 @@
 //     shares for every receiver under the receiver's share-encryption key.
 //  3. Each receiver decrypts and aggregates the collected shares to reconstruct
 //     its Lagrange evaluation point of the combined secret key SK = Σ sk_j.
-//  4. Two values are encrypted under the combined mbfv PublicKey, multiplied and
-//     relinearized using the aggregated RLK, then threshold-decrypted by t+1 parties.
+//  4. Four values are encrypted under the combined mbfv PublicKey, multiplied
+//     in three chained multiplications with relinearization after each, then
+//     threshold-decrypted by t+1 parties.
 #![allow(missing_docs)]
 
 mod util;
@@ -46,18 +50,44 @@ use rayon::prelude::*;
 use std::time::Instant;
 use util::timeit::timeit;
 
+// Preset parameter set for this example. The smudging feasibility of the exact
+// trBFV configuration below (degree, plaintext, moduli, n, lambda) is pinned by
+// the `preset_smudging_feasible` test in this file — see issue #113.
+// Caveat: this preset is verified consistent with the implemented noise/smudging
+// bounds (correctness), but has not been independently checked against an RLWE
+// estimator for computational security.
+const DEGREE: usize = 16384;
+const PLAINTEXT_MODULUS_TRBFV: u64 = 1_000;
+const MODULI_TRBFV: [u64; 5] = [
+    0x003fffffffef8001, // 18014398508400641 (largest)
+    0x003fffffffeb8001, // 18014398508138497
+    0x003fffffffe38001, // 18014398507614209
+    0x003fffffffdd8001, // 18014398507220993
+    0x003fffffffd78001, // 18014398506827777
+];
+const PLAINTEXT_MODULUS_SHARE_ENC: u64 = MODULI_TRBFV[0]; // largest trBFV modulus
+const MODULI_SHARE_ENC: [u64; 2] = [0x3fffffffffd78001u64, 0x3fffffffffe80001];
+const DEFAULT_NUM_PARTIES: usize = 19;
+const DEFAULT_THRESHOLD: usize = 9;
+const DEFAULT_LAMBDA: usize = 38;
+
 fn print_notice_and_exit(error: Option<String>) {
     println!(
         "{} Threshold BFV multiplication with encrypted share transport",
         style("  overview:").magenta().bold()
     );
     println!(
-        "{} trbfv_mul_bfv_share [-h] [--num_parties=N] [--threshold=T] [--lambda=L]",
+        "{} trbfv_mul_bfv_share_binding [-h] [--num_parties=N] [--threshold=T] [--lambda=L]",
         style("     usage:").magenta().bold()
     );
     println!(
-        "{} T ≤ (N-1)/2, N ≥ 1, L ≥ 1",
+        "{} T = (N-1)/2, N ≥ 3, L ≥ {}. Paper-conforming robustness requires odd N (N = 2t + 1);",
         style("constraints:").magenta().bold(),
+        fhe::trbfv::MIN_SECURE_LAMBDA,
+    );
+    println!(
+        "{} even N is accepted for compatibility but lies outside the paper's theorem.",
+        style("           ").magenta().bold(),
     );
     if let Some(error) = error {
         println!("{} {}", style("     error:").red().bold(), error);
@@ -67,15 +97,10 @@ fn print_notice_and_exit(error: Option<String>) {
 
 fn main() -> Result<(), Box<dyn Error>> {
     // ── First BFV parameter set (threshold computation) ──────────────────────
-    // n=5, z=3, k=1000, λ=40, σ²=10. Four 61-bit NTT primes, each ≡ 1 mod 32768. ✓
-    let degree = 16384usize;
-    let plaintext_modulus_trbfv: u64 = 1_000;
-    let moduli_trbfv = [
-        0x1fffffffffe10001u64, // q[1] = 2305843009211662337
-        0x1fffffffffe00001,    // q[2] = 2305843009210613761
-        0x1fffffffffdd0001,    // q[3] = 2305843009196982273
-        0x1fffffffffd08001,    // q[4] = 2305843009177763841
-    ];
+    // n=19, t=9, k=1000, λ=38, σ²=10. Five 54-bit NTT primes, each ≡ 1 mod 32768. ✓
+    let degree = DEGREE;
+    let plaintext_modulus_trbfv = PLAINTEXT_MODULUS_TRBFV;
+    let moduli_trbfv = MODULI_TRBFV;
 
     println!("Building trBFV parameters (first set)...");
     let params_trbfv: Arc<bfv::BfvParameters> = timeit!(
@@ -85,7 +110,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             .set_plaintext_modulus(plaintext_modulus_trbfv)
             .set_moduli(&moduli_trbfv)
             .set_variance(10)
-            // Var(e_1) from the parameter tool: n=5, z=3, λ=40.
+            // Var(e_1) from the earlier parameter-tool design point, retained
+            // unchanged; the `preset_smudging_feasible` test pins the feasibility
+            // of this configuration.
             .set_error1_variance_str("4326914048779023023775413607683413333")?
             .build_arc()?
     );
@@ -100,11 +127,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // ── Second BFV parameter set (share encryption) ───────────────────────────
-    // Plaintext modulus = q[1] of the first set ≈ 2^61. All Shamir share values
-    // lie in [0, q_i) ⊆ [0, q[1]) = [0, k), so they fit as BFV plaintexts.
-    // Two 62-bit NTT primes (≡ 1 mod 32768). Correctness: k ≈ 2^61 < q₀/2 ≈ 2^61.0000003 ✓
-    let plaintext_modulus_share_enc: u64 = moduli_trbfv[0]; // = q[1]
-    let moduli_share_enc = [0x3fffffffffd78001u64, 0x3fffffffffe80001];
+    // Plaintext modulus = largest trBFV modulus ≈ 2^54, so every Shamir share
+    // value (each in [0, q_i) ⊆ [0, k)) encodes directly as a BFV plaintext.
+    // Two 62-bit NTT primes (≡ 1 mod 32768), coprime to the plaintext modulus.
+    // Correctness: BFV decrypt rounds t·v/Q, which recovers the message exactly
+    // iff the error stays below Δ/2 ≈ Q/(2k); a fresh-noise sanity check for
+    // this preset leaves ≈ 58 bits of Δ/2 headroom.
+    let plaintext_modulus_share_enc = PLAINTEXT_MODULUS_SHARE_ENC; // = q[0]
+    let moduli_share_enc = MODULI_SHARE_ENC;
     println!("\nBuilding share-encryption parameters (second set)...");
     let params_share_enc: Arc<bfv::BfvParameters> = timeit!(
         "Parameters generation (share enc)",
@@ -132,10 +162,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         print_notice_and_exit(None)
     }
 
-    // Defaults: n=5 keeps the example fast; the params are correct for n up to 20.
-    let mut num_parties = 5usize;
-    let mut threshold = 2usize;
-    let mut lambda = 40usize;
+    // Defaults: n=19 (odd, paper-conforming 2t+1) tuned to this preset; the
+    // `preset_smudging_feasible` test pins smudging feasibility for this exact
+    // configuration (issue #113).
+    let mut num_parties = DEFAULT_NUM_PARTIES;
+    let mut threshold = DEFAULT_THRESHOLD;
+    let mut lambda = DEFAULT_LAMBDA;
 
     fn parse_opt(arg: &str, prefix: &str) -> Option<usize> {
         arg.strip_prefix(prefix)
@@ -155,21 +187,23 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    if num_parties == 0 || lambda == 0 {
-        print_notice_and_exit(Some("Party count and lambda must be nonzero".to_string()))
-    }
-    if threshold > (num_parties - 1) / 2 {
+    if num_parties < 3 || lambda == 0 {
         print_notice_and_exit(Some(
-            "Threshold must be at most (num_parties - 1) / 2".to_string(),
+            "Party count must be at least 3 and lambda must be nonzero".to_string(),
+        ))
+    }
+    if threshold != (num_parties - 1) / 2 {
+        print_notice_and_exit(Some(
+            "Threshold must be exactly (num_parties - 1) / 2: maximal corruption tolerance with honest-majority reconstruction".to_string(),
         ))
     }
 
-    // λ=40 is the design point of this parameter set (above the library's MIN_SECURE_LAMBDA=35).
-    let security = Lambda::insecure(lambda);
+    // λ=38 is the design point of this preset (≥ fhe::trbfv::MIN_SECURE_LAMBDA=35).
+    let security = Lambda::secure(lambda)?;
     let mut rng = rand::rng();
 
     println!("\n# Threshold BFV multiplication");
-    println!("  num_parties = {num_parties}  (params: n=5, k=1000, z=3, λ=40)");
+    println!("  num_parties = {num_parties}  (params: n=19, k=1000, depth=3, λ=38)");
     println!("  threshold   = {threshold}");
     println!("  lambda      = {lambda}");
 
@@ -203,7 +237,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let crp = CommonRandomPoly::new(&params_trbfv, &mut rng)?;
-    let trbfv: TRBFV = TRBFV::new(num_parties, threshold, params_trbfv.clone()).unwrap();
+    let trbfv: TRBFV = TRBFV::new(num_parties, threshold, params_trbfv.clone())?;
     let num_moduli = params_trbfv.moduli().len();
 
     println!("\n💻 Available CPU cores: {}", rayon::current_num_threads());
@@ -211,36 +245,31 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut parties: Vec<Party> = timeit!("Party setup (parallel)", {
         (0..num_parties)
             .into_par_iter()
-            .map(|party_idx| {
+            .map(|party_idx| -> Result<Party, fhe::Error> {
                 let mut rng = rand::rng();
                 let participant_id = (party_idx + 1) as u32;
 
                 // Unique contribution binding for this party.
                 let binding =
-                    ContributionBinding::new(participant_set_ref.clone(), participant_id).unwrap();
+                    ContributionBinding::new(participant_set_ref.clone(), participant_id)?;
 
                 // trBFV keys and Shamir shares.
                 let sk_share = SecretKey::random(&params_trbfv, &mut rng);
-                let pk_share = MBFVPublicKeyShare::new(&sk_share, crp.clone(), &mut rng).unwrap();
+                let pk_share = MBFVPublicKeyShare::new(&sk_share, crp.clone(), &mut rng)?;
 
                 let mut share_manager =
-                    ShareManager::new(num_parties, threshold, params_trbfv.clone()).unwrap();
-                let sk_poly = share_manager
-                    .coeffs_to_poly_level0(sk_share.coeffs.clone().as_ref())
-                    .unwrap();
+                    ShareManager::new(num_parties, threshold, params_trbfv.clone())?;
+                let sk_poly =
+                    share_manager.coeffs_to_poly_level0(sk_share.coeffs.clone().as_ref())?;
 
-                let sk_sss = trbfv
-                    .generate_secret_shares_from_poly(sk_poly, &mut rng)
-                    .unwrap();
+                let sk_sss = trbfv.generate_secret_shares_from_poly(sk_poly, &mut rng)?;
 
                 // Smudging noise shares (m=1 ciphertext, depth=3 multiplications).
-                let esi_coeffs = trbfv
-                    .generate_smudging_error(1, 3, security, &mut rng)
-                    .unwrap();
-                let esi_poly = share_manager.bigints_to_poly(&esi_coeffs).unwrap();
-                let esi_sss = share_manager
-                    .generate_secret_shares_from_poly(esi_poly, &mut rng)
-                    .unwrap();
+                // An infeasible configuration is propagated out of main (issue
+                // #113) rather than panicking inside the Rayon worker.
+                let esi_coeffs = trbfv.generate_smudging_error(1, 3, security, &mut rng)?;
+                let esi_poly = share_manager.bigints_to_poly(&esi_coeffs)?;
+                let esi_sss = share_manager.generate_secret_shares_from_poly(esi_poly, &mut rng)?;
 
                 // l-BFV PK contribution (CRS seed = pk_seed, shared by all parties).
                 let pk_lbfv_share = PublicKeyShare::new_with_seed_and_binding(
@@ -248,22 +277,20 @@ fn main() -> Result<(), Box<dyn Error>> {
                     pk_seed,
                     binding.clone(),
                     &mut rng,
-                )
-                .unwrap();
+                )?;
 
                 // l-BFV RLK share for SK = Σ sk_j.
                 let rlk_share = RelinKeyShare::contribution_with_binding(
                     &sk_share, d1_seed, pk_seed, // a_seed must match pk_lbfv_share's CRS seed
                     binding, 0, 0, &mut rng,
-                )
-                .unwrap();
+                )?;
 
                 // Share-encryption key pair under the second parameter set.
                 let sk_share_enc = SecretKey::random(&params_share_enc, &mut rng);
                 let pk_share_enc = PublicKey::new(&sk_share_enc, &mut rng);
 
-                let ctx0 = params_trbfv.context_at_level(0).unwrap();
-                Party {
+                let ctx0 = params_trbfv.context_at_level(0)?;
+                Ok(Party {
                     pk_share,
                     sk_sss,
                     esi_sss,
@@ -276,9 +303,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                     rlk_share,
                     sk_share_enc,
                     pk_share_enc,
-                }
+                })
             })
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?
     });
 
     // ── Distributed RLK aggregation ───────────────────────────────────────────
@@ -296,8 +323,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     // ── Share encryption and transmission ─────────────────────────────────────
     // Each sender BFV-encrypts the share row it owes to each receiver under that
     // receiver's share-encryption public key (second parameter set). This is safe:
-    //   • k = q[1] ≥ q_i for all i → share values ∈ [0, q_i) ⊆ [0, k)
-    //   • k ≈ 2^57 < q₀/2 ≈ 2^59  → BFV decrypt is algebraically exact
+    //   • k = largest trBFV modulus ≥ q_i for all i → share values ∈ [0, q_i) ⊆ [0, k)
+    //   • BFV decrypt rounds t·v/Q: exact recovery needs the error below
+    //     Δ/2 ≈ Q/(2k), not merely below Q/2 — fresh noise leaves ≈ 58 bits
+    //     of Δ/2 headroom for this preset
     //
     // encrypted_shares[sender][receiver] = (Vec<Ciphertext>, Vec<Ciphertext>)
     //   first  vec: one ciphertext per modulus for the sk share row
@@ -475,4 +504,48 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fhe::trbfv::{SmudgingBoundCalculator, SmudgingBoundCalculatorConfig};
+
+    /// The exact trBFV preset this example runs with (degree, plaintext modulus,
+    /// moduli, n = `DEFAULT_NUM_PARTIES`, lambda = `DEFAULT_LAMBDA`, one
+    /// ciphertext, three chained multiplications, all parties accepted into the
+    /// l-BFV relinearization set) must yield a feasible smudging bound.
+    ///
+    /// Regression guard for issue #113: this preset was previously infeasible and
+    /// the examples panicked inside Rayon worker closures instead of reporting the
+    /// `SmudgingBoundInfeasible` error.
+    #[test]
+    fn preset_smudging_feasible() {
+        let params = bfv::BfvParametersBuilder::new()
+            .set_degree(DEGREE)
+            .set_plaintext_modulus(PLAINTEXT_MODULUS_TRBFV)
+            .set_moduli(&MODULI_TRBFV)
+            .set_variance(10)
+            .set_error1_variance_str("4326914048779023023775413607683413333")
+            .unwrap()
+            .build_arc()
+            .unwrap();
+
+        let config = SmudgingBoundCalculatorConfig::new_multiplicative(
+            params,
+            DEFAULT_NUM_PARTIES,
+            1, // m: a single ciphertext, as in the example
+            3, // mult_depth: three chained multiplications, as in the example
+            Lambda::secure(DEFAULT_LAMBDA).unwrap(),
+        )
+        .unwrap();
+        let bound = SmudgingBoundCalculator::new(config)
+            .with_accepted_participant_count(DEFAULT_NUM_PARTIES)
+            .calculate_sm_bound();
+        assert!(
+            bound.is_ok(),
+            "the preset trBFV configuration must be smudging-feasible, got: {}",
+            bound.unwrap_err()
+        );
+    }
 }

--- a/crates/fhe/src/trbfv/README.md
+++ b/crates/fhe/src/trbfv/README.md
@@ -66,9 +66,16 @@ Let `mult_depth` be the number of multiplication levels.
     with **aggregate RLK error** `|S| &middot; B_e`, where `|S|` is the
     `accepted_participant_count` (the size of the *l*-BFV accepted set).
 
-- **Smudging bound:** `B&#x209b;&#x2098; = 2^(lambda) &middot; B&#x1d9c;` where
+- **Smudging bound:** `B&#x209b;&#x2098; = 2^(lambda + 1) &middot; d &middot; B&#x1d9c;` where
   `lambda` is the statistical security parameter (see
-  [`MIN_SECURE_LAMBDA`]).
+  [`MIN_SECURE_LAMBDA`]) and `d` is the polynomial ring degree. The extra
+  factor `2 &middot; d` is the whole-transcript policy (issue #108): a single
+  decryption reveals all `d` coefficients of the smudging noise at once, so a
+  union bound over the coefficients adds a factor `d`, and `2^(lambda + 1)`
+  keeps the constant-`2` convention of the correctness inequality. The older
+  `B&#x209b;&#x2098; = 2^lambda &middot; B&#x1d9c;` form only bounds the
+  statistical distance for a *single* coefficient and is not what
+  [`smudging.rs`](smudging.rs) implements.
 
 ### Sampler-specific `B_enc`
 

--- a/crates/fhe/src/trbfv/shares.rs
+++ b/crates/fhe/src/trbfv/shares.rs
@@ -4,6 +4,7 @@ use crate::Error;
 /// This module provides the ShareManager struct that handles aggregation of secret shares
 /// and computation of decryption shares in the threshold BFV scheme.
 use crate::bfv::{BfvParameters, Ciphertext, Plaintext};
+use crate::trbfv::config::validate_threshold_config;
 use crate::trbfv::shamir::ShamirSecretSharing;
 use fhe_math::rq::traits::TryConvertFrom;
 use fhe_math::zq::Modulus;
@@ -28,6 +29,14 @@ use zeroize::Zeroizing;
 /// ShareManager coordinates the collection and processing of secret shares in the threshold BFV scheme.
 /// It handles both the aggregation of collected shares and the computation of decryption shares.
 ///
+/// # Threshold semantics
+///
+/// `threshold` is the degree `T` of the Shamir sharing polynomial, read as the
+/// maximum number of corrupted parties the deployment tolerates. Reconstruction
+/// requires `T + 1` shares. As a trBFV type, `ShareManager` enforces the same
+/// invariants as [`TRBFV`](crate::trbfv::TRBFV): `n >= 3` and `T = (n - 1) / 2`
+/// (see [`validate_threshold_config`]).
+///
 /// # Protocol Flow
 /// 1. Each party generates secret shares using secret sharing
 /// 2. Parties exchange shares through secure channels
@@ -36,9 +45,11 @@ use zeroize::Zeroizing;
 /// 5. Finally, threshold number of decryption shares are combined to decrypt
 #[derive(Debug)]
 pub struct ShareManager {
-    /// Number of parties in the threshold scheme
+    /// Number of parties in the threshold scheme (must be `>= 3`)
     pub n: usize,
-    /// Threshold for reconstruction (minimum shares needed)
+    /// Degree `T` of the Shamir sharing polynomial, i.e. the maximum number of
+    /// corrupted parties the deployment tolerates (must equal `(n - 1) / 2`).
+    /// Reconstruction requires `T + 1` shares.
     pub threshold: usize,
     /// BFV parameters (degree, moduli, etc.)
     pub params: Arc<BfvParameters>,
@@ -58,15 +69,22 @@ impl ShareManager {
     /// Create a new share manager.
     ///
     /// # Arguments
-    /// - `n`: Total number of parties
-    /// - `threshold`: Minimum number of shares required for reconstruction
+    /// - `n`: Total number of parties (must be `>= 3`)
+    /// - `threshold`: Degree `T` of the Shamir sharing polynomial, i.e. the
+    ///   maximum number of corrupted parties the deployment tolerates. Must
+    ///   equal `(n - 1) / 2`; reconstruction requires `T + 1` shares.
     /// - `params`: BFV parameters
     ///
     /// # Errors
-    /// Returns an error if the parameters have no moduli, or if `n` is not
-    /// smaller than the smallest modulus (the MPC protocol assumes the Shamir
-    /// evaluation points `1..=n` are distinct units modulo every modulus).
+    /// Returns an error if `n < 3` or `threshold != (n - 1) / 2` (a degree-0
+    /// sharing polynomial would reveal the secret to every party), if the
+    /// parameters have no moduli, or if `n` is not smaller than the smallest
+    /// modulus (the MPC protocol assumes the Shamir evaluation points `1..=n`
+    /// are distinct units modulo every modulus).
     pub fn new(n: usize, threshold: usize, params: Arc<BfvParameters>) -> Result<Self, Error> {
+        // Enforce the same `n >= 3` and `T = (n - 1) / 2` invariants as TRBFV.
+        validate_threshold_config(n, threshold)?;
+
         //Note that in case we consider in the future using qi's that are not prime numbers (so
         //they would be only satisfying the condition of being coprime to each other which is
         //sufficient for Greco etc), we can use the utility get_smallest_prime_factor implemented
@@ -576,6 +594,79 @@ mod tests {
     }
 
     #[test]
+    fn test_share_manager_rejects_threshold_zero() {
+        // Regression: `ShareManager::new(5, 0)` was previously accepted even
+        // though a degree-0 Shamir sharing polynomial is the secret itself, so
+        // every party would hold the full secret.
+        let params = test_params();
+        let err = ShareManager::new(5, 0, params)
+            .expect_err("threshold 0 must be rejected (degree-0 sharing reveals the secret)");
+        assert!(matches!(
+            err,
+            Error::Threshold(ThresholdError::InvalidThreshold {
+                threshold: 0,
+                n: 5,
+                expected: 2
+            })
+        ));
+    }
+
+    #[test]
+    fn test_share_manager_rejects_invalid_threshold_config() {
+        let params = test_params();
+
+        // n < 3 cannot host any valid threshold.
+        for (n, threshold) in [(0usize, 1usize), (1, 0), (1, 1), (2, 0), (2, 1)] {
+            assert!(
+                ShareManager::new(n, threshold, params.clone()).is_err(),
+                "ShareManager::new({n}, {threshold}) must be rejected"
+            );
+        }
+
+        // threshold == 0 (a degree-0 sharing reveals the secret to every party).
+        for n in [3usize, 5, 20] {
+            assert!(
+                ShareManager::new(n, 0, params.clone()).is_err(),
+                "ShareManager::new({n}, 0) must be rejected"
+            );
+        }
+
+        // threshold above (n - 1) / 2: the honest parties could not gather
+        // threshold + 1 shares, losing guaranteed reconstruction.
+        for (n, threshold) in [(5usize, 3usize), (5, 4), (5, 5), (5, 6), (3, 2)] {
+            assert!(
+                ShareManager::new(n, threshold, params.clone()).is_err(),
+                "ShareManager::new({n}, {threshold}) must be rejected"
+            );
+        }
+
+        // threshold below (n - 1) / 2: a maximal corrupted coalition would
+        // hold threshold + 1 shares and reconstruct the secret on its own.
+        for (n, threshold) in [(20usize, 8usize), (20, 7), (10, 3)] {
+            assert!(
+                ShareManager::new(n, threshold, params.clone()).is_err(),
+                "ShareManager::new({n}, {threshold}) must be rejected"
+            );
+        }
+
+        // For even n, T = n / 2 also fails under the (n - 1) / 2 cap.
+        assert!(ShareManager::new(20, 10, params.clone()).is_err());
+        assert!(ShareManager::new(4, 2, params.clone()).is_err());
+    }
+
+    #[test]
+    fn test_share_manager_accepts_valid_threshold_config() {
+        let params = test_params();
+        // Exactly T = (n - 1) / 2, covering odd n, even n, and the minimum n.
+        for (n, threshold) in [(3usize, 1usize), (4, 1), (5, 2), (10, 4), (20, 9), (21, 10)] {
+            let manager = ShareManager::new(n, threshold, params.clone())
+                .expect("a valid threshold config must be accepted");
+            assert_eq!(manager.n, n);
+            assert_eq!(manager.threshold, threshold);
+        }
+    }
+
+    #[test]
     fn test_coeffs_to_poly_utility() {
         let params = test_params();
         let manager = ShareManager::new(5, 2, params.clone()).unwrap();
@@ -595,7 +686,7 @@ mod tests {
     #[test]
     fn test_bigints_to_poly() {
         let params = test_params();
-        let manager = ShareManager::new(5, 3, params.clone()).unwrap();
+        let manager = ShareManager::new(5, 2, params.clone()).unwrap();
 
         // Create BigInt coefficients (full degree)
         let degree = params.degree();
@@ -622,10 +713,10 @@ mod tests {
         let mut rng = rng();
         let params = test_params();
         let n = 3;
-        //Fix threshold to be 0 for the purpose of this test so that any single party can decrypt.
-        //I.e., the secret key is given to all parties and not secret shared
-        let threshold = 0;
-        let manager = ShareManager::new(n.try_into().unwrap(), threshold, params.clone()).unwrap();
+        // ShareManager now enforces T = (n - 1) / 2, so the minimal valid
+        // configuration is (n = 3, threshold = 1), requiring two shares.
+        let threshold = 1;
+        let manager = ShareManager::new(n, threshold, params.clone()).unwrap();
 
         // Setup: Generate keys and encrypt a plaintext
         let sk = SecretKey::random(&params, &mut rng);
@@ -635,7 +726,6 @@ mod tests {
         plaintext_data.resize(params.degree(), 0);
         let pt = Plaintext::try_encode(&plaintext_data, Encoding::poly(), &params).unwrap();
         let ct: Arc<Ciphertext> = Arc::new(pk.try_encrypt(&pt, &mut rng).unwrap());
-        //let ct = pk.try_encrypt(&pt, &mut rng).unwrap();
 
         // Generate polynomials for decryption share
         let sk_poly = manager.coeffs_to_poly_level0(sk.coeffs.as_ref()).unwrap();
@@ -648,10 +738,14 @@ mod tests {
             .decryption_share(ct.clone(), (*sk_poly).clone().into_ntt(), es_poly)
             .unwrap();
 
-        let shares = vec![decryption_share.clone()];
+        // This unit test uses the full secret as the "aggregate" for both
+        // parties; two identical values at distinct Shamir x-coordinates
+        // interpolate to a constant polynomial and reconstruct to the same
+        // value, which is exactly what the plaintext recovery needs.
+        let shares = vec![decryption_share.clone(), decryption_share];
 
-        // Only party 1 participates (since threshold = 0, one share is enough). Parties are 1-based.
-        let reconstructing = vec![1];
+        // Parties are 1-based; reconstruction needs threshold + 1 = 2 shares.
+        let reconstructing = vec![1, 2];
         let result = manager.decrypt_from_shares(shares, reconstructing, ct);
         let plaintext_found = result.expect("Failed to decrypt from shares");
 
@@ -665,7 +759,7 @@ mod tests {
     fn test_decryption_share_rejects_nonzero_ciphertext_level() {
         let mut rng = rng();
         let params = test_params();
-        let manager = ShareManager::new(3, 0, params.clone()).unwrap();
+        let manager = ShareManager::new(3, 1, params.clone()).unwrap();
         let secret_key = SecretKey::random(&params, &mut rng);
         let public_key = PublicKey::new(&secret_key, &mut rng);
         let plaintext = Plaintext::try_encode(&[42u64], Encoding::poly(), &params).unwrap();
@@ -694,7 +788,7 @@ mod tests {
     fn test_decrypt_from_shares_rejects_nonzero_ciphertext_level() {
         let mut rng = rng();
         let params = test_params();
-        let manager = ShareManager::new(3, 0, params.clone()).unwrap();
+        let manager = ShareManager::new(3, 1, params.clone()).unwrap();
         let secret_key = SecretKey::random(&params, &mut rng);
         let public_key = PublicKey::new(&secret_key, &mut rng);
         let plaintext = Plaintext::try_encode(&[42u64], Encoding::poly(), &params).unwrap();
@@ -883,7 +977,7 @@ mod tests {
         let mut rng = rng();
         let params = test_params();
         let n = 20;
-        let threshold = 7; // need 8 parties
+        let threshold = 9; // (n - 1) / 2 for n = 20; need 10 parties
 
         let ctx = params.context_at_level(0).unwrap();
 
@@ -928,10 +1022,10 @@ mod tests {
         let pt = Plaintext::try_encode(&plaintext_data, Encoding::poly(), &params).unwrap();
         let ct = Arc::new(pk.try_encrypt(&pt, &mut rng).unwrap());
 
-        // Choose arbitrary reconstructing parties (1-based indices): {2,5,7,11,13,17,19,20}
-        // Corresponding 0-based indices: {1,4,6,10,12,16,18,19}
+        // Choose arbitrary reconstructing parties (1-based indices): {2,4,5,7,11,13,15,17,19,20}
+        // Corresponding 0-based indices: {1,3,4,6,10,12,14,16,18,19}
         let chosen_indices = vec![
-            1usize, 4usize, 6usize, 10usize, 12usize, 16usize, 18usize, 19usize,
+            1usize, 3usize, 4usize, 6usize, 10usize, 12usize, 14usize, 16usize, 18usize, 19usize,
         ];
         let reconstructing: Vec<usize> = chosen_indices.iter().map(|x| x + 1).collect();
 

--- a/crates/fhe/tests/trbfv_mul_preset_feasibility.rs
+++ b/crates/fhe/tests/trbfv_mul_preset_feasibility.rs
@@ -1,0 +1,351 @@
+//! Preset-level smudging feasibility and depth-3 end-to-end coverage for the
+//! multiplicative trBFV examples.
+//!
+//! Regression guard for issue #113: the multiplication examples
+//! (`crates/fhe/examples/trbfv_mul_bfv_share.rs` and
+//! `trbfv_mul_bfv_share_binding.rs`) previously declared smudging-infeasible
+//! parameter sets and panicked inside Rayon worker closures at runtime. The
+//! constants below MUST match the presets declared in those two example files;
+//! when an example preset is retuned, update this file in the same change.
+
+#![allow(clippy::indexing_slicing, clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use fhe::bfv::{self, BfvParameters, Ciphertext, Encoding, Plaintext, SecretKey};
+use fhe::mbfv::AggregateIter;
+use fhe::trbfv::{
+    Lambda, ShareManager, SmudgingBoundCalculator, SmudgingBoundCalculatorConfig, TRBFV,
+};
+use fhe::trlbfv::{
+    AggregatedPublicKey, ContributionBinding, ParticipantSet, PublicKeyShare, RelinKeyShare,
+    aggregate_relinearization_key,
+};
+use fhe_math::rq::{Poly, PowerBasis};
+use fhe_traits::{FheDecoder, FheEncoder, FheEncrypter};
+use ndarray::{Array, Array2};
+use num_bigint::{BigInt, BigUint};
+use rand::{Rng, SeedableRng, rng};
+use rand_chacha::ChaCha8Rng;
+use rayon::prelude::*;
+
+// ── trBFV preset of the multiplication examples ────────────────────────────
+const DEGREE: usize = 16384;
+const NUM_PARTIES: usize = 19; // odd n = 2t + 1, paper-conforming
+const THRESHOLD: usize = 9; // (n - 1) / 2, maximal corruption tolerance
+const LAMBDA: usize = 38;
+const M: usize = 1; // single ciphertext, as in the examples
+const MULT_DEPTH: u32 = 3; // three chained multiplications
+const PLAINTEXT_MODULUS_TRBFV: u64 = 1_000;
+const TRBFV_MODULI: &[u64] = &[
+    0x003fffffffef8001, // 18014398508400641 (largest)
+    0x003fffffffeb8001, // 18014398508138497
+    0x003fffffffe38001, // 18014398507614209
+    0x003fffffffdd8001, // 18014398507220993
+    0x003fffffffd78001, // 18014398506827777
+];
+const TRBFV_ERROR1_VARIANCE: &str = "4326914048779023023775413607683413333";
+
+// ── Share-encryption preset of the multiplication examples ─────────────────
+// Plaintext modulus = largest trBFV modulus, so every Shamir residue
+// (in [0, q_i) for each trBFV modulus q_i) encodes directly as a BFV plaintext.
+const PLAINTEXT_MODULUS_SHARE_ENC: u64 = TRBFV_MODULI[0];
+const SHARE_ENC_MODULI: &[u64] = &[0x3fffffffffd78001, 0x3fffffffffe80001];
+
+fn trbfv_params() -> Arc<BfvParameters> {
+    bfv::BfvParametersBuilder::new()
+        .set_degree(DEGREE)
+        .set_plaintext_modulus(PLAINTEXT_MODULUS_TRBFV)
+        .set_moduli(TRBFV_MODULI)
+        .set_variance(10)
+        .set_error1_variance_str(TRBFV_ERROR1_VARIANCE)
+        .unwrap()
+        .build_arc()
+        .unwrap()
+}
+
+/// The exact preset of the two multiplicative examples must yield a feasible
+/// smudging bound (issue #113). An infeasible preset used to panic inside the
+/// Rayon worker closures of the examples instead of reporting the
+/// `SmudgingBoundInfeasible` error.
+#[test]
+fn mul_bfv_share_examples_preset_smudging_feasible() {
+    let params = trbfv_params();
+    let config = SmudgingBoundCalculatorConfig::new_multiplicative(
+        params,
+        NUM_PARTIES,
+        M,
+        MULT_DEPTH,
+        Lambda::secure(LAMBDA).unwrap(),
+    )
+    .unwrap();
+    let bound = SmudgingBoundCalculator::new(config)
+        .with_accepted_participant_count(NUM_PARTIES)
+        .calculate_sm_bound()
+        .expect("the multiplication-example preset must be smudging-feasible");
+    assert!(
+        bound > BigUint::from(0_u64),
+        "a feasible preset must produce a strictly positive smudging bound"
+    );
+}
+
+/// The share-encryption plaintext modulus is the largest trBFV modulus, so
+/// every Shamir share value (a residue of one of the trBFV moduli) fits into a
+/// share-encryption plaintext.
+#[test]
+fn share_enc_plaintext_modulus_covers_trbfv_moduli() {
+    let max_trbfv_modulus = *TRBFV_MODULI.iter().max().unwrap();
+    assert_eq!(
+        PLAINTEXT_MODULUS_SHARE_ENC, max_trbfv_modulus,
+        "share-encryption plaintext modulus must equal the largest trBFV modulus"
+    );
+    // What this verifies: every Shamir share value is a residue of one of the
+    // trBFV moduli, and the largest trBFV modulus equals the share-encryption
+    // plaintext modulus — so every share value fits the share-encryption
+    // plaintext space. Decryption correctness (noise budget) is not verified
+    // here; see the example-file comments.
+    assert!(
+        SHARE_ENC_MODULI
+            .iter()
+            .all(|&q| q > PLAINTEXT_MODULUS_SHARE_ENC),
+        "every share-encryption modulus must exceed the plaintext modulus"
+    );
+}
+
+/// The preset threshold is the maximal corruption tolerance of the honest
+/// majority: t = (n - 1) / 2 (paper-conforming odd n = 2t + 1).
+#[test]
+fn preset_threshold_is_maximal_corruption_tolerance() {
+    assert_eq!(THRESHOLD, (NUM_PARTIES - 1) / 2);
+    assert_eq!(NUM_PARTIES, 2 * THRESHOLD + 1);
+}
+
+/// Full cryptographic-core depth-3 test of the exact multiplication-example
+/// preset, as a CI test (issue #113): distributed l-BFV PK/RLK, Shamir
+/// sharing of keys and smudging noise, three chained multiplications with
+/// relinearization, and threshold decryption with `threshold + 1` shares.
+/// Unlike the examples, it does not exercise the encrypted share transport
+/// or the binding example's MBFV public-key aggregation path.
+#[test]
+fn mul_examples_preset_depth3_e2e() {
+    let params = trbfv_params();
+    let trbfv =
+        TRBFV::new(NUM_PARTIES, THRESHOLD, params.clone()).expect("n=19, t=9 must validate");
+
+    let mut rng = rng();
+    let crs_seed = {
+        let mut seed = <ChaCha8Rng as SeedableRng>::Seed::default();
+        rng.fill(&mut seed);
+        seed
+    };
+    let urs_seed = {
+        let mut seed = <ChaCha8Rng as SeedableRng>::Seed::default();
+        rng.fill(&mut seed);
+        seed
+    };
+
+    let participant_set = ParticipantSet::new([42u8; 32], (1..=NUM_PARTIES as u32).collect())
+        .expect("sorted unique participant IDs");
+
+    // ── Distributed l-BFV public key and relinearization key ────────────
+    let sk_shares: Vec<SecretKey> = (0..NUM_PARTIES)
+        .map(|_| SecretKey::random(&params, &mut rng))
+        .collect();
+
+    let contributions: Vec<(PublicKeyShare, RelinKeyShare)> = sk_shares
+        .par_iter()
+        .enumerate()
+        .map(|(i, sk_i)| {
+            let mut local_rng = rand::rng();
+            let binding = ContributionBinding::new(participant_set.clone(), (i + 1) as u32)
+                .expect("valid contribution binding");
+            let pk_share = PublicKeyShare::new_with_seed_and_binding(
+                sk_i,
+                crs_seed,
+                binding.clone(),
+                &mut local_rng,
+            )
+            .expect("PK contribution generation");
+            let rlk_share = RelinKeyShare::contribution_with_binding(
+                sk_i,
+                urs_seed,
+                crs_seed,
+                binding,
+                0, // ciphertext_level
+                0, // key_level
+                &mut local_rng,
+            )
+            .expect("RLK share generation");
+            (pk_share, rlk_share)
+        })
+        .collect();
+
+    let pk_shares: Vec<PublicKeyShare> = contributions.iter().map(|(pk, _)| pk.clone()).collect();
+    let rlk_shares: Vec<RelinKeyShare> = contributions.iter().map(|(_, rlk)| rlk.clone()).collect();
+    let aggregated_pk = pk_shares
+        .into_iter()
+        .aggregate::<AggregatedPublicKey>()
+        .expect("PK aggregation");
+    let pk = aggregated_pk.operational();
+    let rlk = aggregate_relinearization_key(&rlk_shares, &aggregated_pk).expect("RLK aggregation");
+
+    // ── Smudging noise (one-time pre-shared material) at the preset ──────
+    let smudging_noises: Vec<Vec<BigInt>> = (0..NUM_PARTIES)
+        .map(|_| {
+            trbfv
+                .generate_smudging_error_with_participant_count(
+                    1,
+                    MULT_DEPTH,
+                    NUM_PARTIES, // all n parties contribute to the RLK
+                    Lambda::secure(LAMBDA).expect("secure lambda"),
+                    &mut rng,
+                )
+                .expect("smudging noise generation at the preset must be feasible")
+        })
+        .collect();
+
+    // ── Shamir share deal / collect / aggregate (SK + noise) ─────────────
+    struct Party {
+        sk_sss: Vec<Array2<u64>>,
+        esi_sss: Vec<Array2<u64>>,
+        sk_sss_collected: Vec<Array2<u64>>,
+        es_sss_collected: Vec<Array2<u64>>,
+        sk_poly_sum: Poly<PowerBasis>,
+        es_poly_sum: Poly<PowerBasis>,
+    }
+
+    let ctx_level0 = params.context_at_level(0).expect("level-0 context");
+    let mut parties: Vec<Party> = (0..NUM_PARTIES)
+        .map(|i| {
+            let mut share_manager =
+                ShareManager::new(NUM_PARTIES, THRESHOLD, params.clone()).expect("share manager");
+
+            // Shamir-share this party's secret key.
+            let sk_poly = share_manager
+                .coeffs_to_poly_level0(sk_shares[i].coeffs.clone().as_ref())
+                .expect("sk to poly");
+            let sk_sss = share_manager
+                .generate_secret_shares_from_poly(sk_poly, &mut rng)
+                .expect("sk share generation");
+
+            // Shamir-share this party's smudging noise.
+            let esi_poly = share_manager
+                .bigints_to_poly(&smudging_noises[i])
+                .expect("esi to poly");
+            let esi_sss = share_manager
+                .generate_secret_shares_from_poly(esi_poly, &mut rng)
+                .expect("esi share generation");
+
+            Party {
+                sk_sss,
+                esi_sss,
+                sk_sss_collected: Vec::with_capacity(NUM_PARTIES),
+                es_sss_collected: Vec::with_capacity(NUM_PARTIES),
+                sk_poly_sum: Poly::<PowerBasis>::zero(ctx_level0),
+                es_poly_sum: Poly::<PowerBasis>::zero(ctx_level0),
+            }
+        })
+        .collect();
+
+    // Each party collects the row addressed to it from every other party's
+    // share matrix (simulated as local access, as in the e2e test suite).
+    for receiver_idx in 0..NUM_PARTIES {
+        let mut sk_rows: Vec<Array2<u64>> = Vec::with_capacity(NUM_PARTIES);
+        let mut es_rows: Vec<Array2<u64>> = Vec::with_capacity(NUM_PARTIES);
+        for sender in parties.iter() {
+            let collect_row = |sss: &[Array2<u64>]| -> Array2<u64> {
+                let mut rows = Array::zeros((0, params.degree()));
+                for share_matrix in sss {
+                    let row = share_matrix.row(receiver_idx);
+                    rows.push_row(row).expect("append share row");
+                }
+                rows
+            };
+            sk_rows.push(collect_row(&sender.sk_sss));
+            es_rows.push(collect_row(&sender.esi_sss));
+        }
+        parties[receiver_idx].sk_sss_collected = sk_rows;
+        parties[receiver_idx].es_sss_collected = es_rows;
+    }
+
+    // Aggregate collected SK and noise shares into per-party polynomials.
+    for party in parties.iter_mut() {
+        party.sk_poly_sum = trbfv
+            .aggregate_collected_shares(&party.sk_sss_collected)
+            .expect("aggregate sk shares");
+        party.es_poly_sum = trbfv
+            .aggregate_collected_shares(&party.es_sss_collected)
+            .expect("aggregate es shares");
+    }
+
+    // ── Encrypt, chain three multiplications with relinearization ────────
+    let mut encrypt = |value: u64| -> Ciphertext {
+        let pt = Plaintext::try_encode(&[value], Encoding::poly(), &params).expect("encode");
+        pk.try_encrypt(&pt, &mut rng).expect("encryption")
+    };
+
+    let a = 3u64;
+    let b = 5u64;
+    let c = 2u64;
+    let d = 4u64;
+    let ct_a = encrypt(a);
+    let ct_b = encrypt(b);
+    let ct_c = encrypt(c);
+    let ct_d = encrypt(d);
+
+    let mut ct_ab = &ct_a * &ct_b;
+    assert_eq!(ct_ab.len(), 3, "multiplication must yield 3 components");
+    rlk.relinearizes(&mut ct_ab).expect("relinearization 1");
+    assert_eq!(ct_ab.len(), 2, "relinearization must yield 2 components");
+
+    let mut ct_abc = &ct_ab * &ct_c;
+    rlk.relinearizes(&mut ct_abc).expect("relinearization 2");
+
+    let mut ct_abcd = &ct_abc * &ct_d;
+    rlk.relinearizes(&mut ct_abcd).expect("relinearization 3");
+    assert_eq!(ct_abcd.len(), 2);
+
+    let tally = Arc::new(ct_abcd);
+
+    // ── Threshold decryption with exactly threshold + 1 shares ───────────
+    let reconstructing: Vec<usize> = (1..=THRESHOLD + 1).collect();
+    assert_eq!(reconstructing.len(), THRESHOLD + 1);
+
+    let d_share_polys: Vec<Poly<PowerBasis>> = reconstructing
+        .iter()
+        .map(|&party_id| {
+            let party = &parties[party_id - 1];
+            trbfv
+                .decryption_share(
+                    tally.clone(),
+                    party.sk_poly_sum.clone().into_ntt(),
+                    party.es_poly_sum.clone(),
+                )
+                .expect("decryption share")
+        })
+        .collect();
+
+    // A single share must be insufficient.
+    let one_share_result = trbfv.decrypt(
+        vec![d_share_polys[0].clone()],
+        vec![reconstructing[0]],
+        tally.clone(),
+    );
+    assert!(
+        one_share_result.is_err(),
+        "single share must not decrypt (threshold requires {} shares)",
+        THRESHOLD + 1
+    );
+
+    // Exactly threshold + 1 shares must decrypt to the correct product.
+    let decrypted = trbfv
+        .decrypt(d_share_polys, reconstructing, tally)
+        .expect("threshold decryption with t+1 shares");
+    let result_vec = Vec::<u64>::try_decode(&decrypted, Encoding::poly()).expect("decode result");
+    let expected = a * b * c * d;
+    assert_eq!(
+        result_vec[0], expected,
+        "threshold decryption must recover {a} * {b} * {c} * {d} = {expected}, got {}",
+        result_vec[0]
+    );
+}


### PR DESCRIPTION
## Summary

Implements the issue #113 verdict and fixes the related smudging-bound regression in the trbfv multiplication examples.

### Issue #113 — ShareManager threshold validation
- `ShareManager::new` now calls `validate_threshold_config(n, threshold)?` first, enforcing `n >= 3` and `T = (n - 1) / 2` (rejecting degree-0 sharings that reveal the secret to every party).
- Docs describe `threshold` as the Shamir polynomial degree / corruption threshold; reconstruction requires `T + 1` shares.
- Regression test for the exact reported case (`n = 5, threshold = 0`) plus invalid/valid configuration matrices; 5 existing tests updated to valid configs.

### Smudging-bound regression (from #144)
- The two multiplication examples were never retuned for the whole-transcript bound `B_sm = 2^(lambda+1) * d * B_C` and panicked at runtime with `SmudgingBoundInfeasible`. Retuned to five 54-bit moduli, `n=19, t=9, lambda=38` (~9.6 bits of headroom; share-encryption set included), with `T = (N-1)/2` CLI guards, `N >= 3` validation, and `SmudgingBoundInfeasible` propagated out of `main` instead of panicking in Rayon workers.
- New `tests/trbfv_mul_preset_feasibility.rs`: preset feasibility via the bound calculator, share-fit, threshold-maximality, and a depth-3 e2e at the exact preset (~53s release).
- `trbfv/README.md` smudging formula updated to the current `2^(lambda+1) * d * B_C` form.

### Rules
- `.rules/cryptography.md`: 4.8 extended (ShareManager validation), new 4.10 (preset feasibility invariant).
- `.rules/testing.md`: new item 12 (preset-level feasibility tests).

## Verification
- `cargo test --release --all-features` — 336 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Both examples run end-to-end in release (decrypt `12` / `20` correctly); `--lambda=48` and `--num_parties=1` exit cleanly with propagated errors.

## Caveats
- The new parameter set is verified consistent with the implemented noise/smudging bounds (correctness) but has not been independently checked against an RLWE estimator; the parameter-search tool is being updated for the current formula (theinterfold/interfold#1857).
- Remaining known-infeasible presets (`trbfv_add.rs`, `trbfv_bfv_share` bench) and the example-preset refactor are tracked in #168 (child of #132).

Closes #113
